### PR TITLE
[FIX](17.0_Dockerfile): add git

### DIFF
--- a/.resources/dockerfiles/17.0_Dockerfile
+++ b/.resources/dockerfiles/17.0_Dockerfile
@@ -11,7 +11,7 @@ RUN useradd -md /home/odoo -s /bin/false odoo \
 # Install debian packages
 RUN set -x ; \
     apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends watchdog curl apt-transport-https build-essential ca-certificates curl ffmpeg file flake8 fonts-freefont-ttf fonts-noto-cjk gawk gnupg gsfonts libldap2-dev libjpeg9-dev libsasl2-dev libxslt1-dev lsb-release ocrmypdf sed sudo unzip xfonts-75dpi zip zlib1g-dev \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends watchdog git curl apt-transport-https build-essential ca-certificates curl ffmpeg file flake8 fonts-freefont-ttf fonts-noto-cjk gawk gnupg gsfonts libldap2-dev libjpeg9-dev libsasl2-dev libxslt1-dev lsb-release ocrmypdf sed sudo unzip xfonts-75dpi zip zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Install debian packages


### PR DESCRIPTION
Error: 

```
 => [odoo 14/25] RUN python3 -m pip install --no-cache-dir -r /tmp/requirements.txt                                                                                                     16.5s
 => ERROR [odoo 15/25] RUN python3 -m pip install --no-cache-dir watchdog xmltodict pandas bravado_core swagger_spec_validator jsonschema==3.2.0 pdf2image xmltodict git+https://github  0.6s
------
 > [odoo 15/25] RUN python3 -m pip install --no-cache-dir watchdog xmltodict pandas bravado_core swagger_spec_validator jsonschema==3.2.0 pdf2image xmltodict git+https://github.com/binaural-
dev/python-sdk.git cryptography==35.0.0 watchdog:
0.532 Collecting git+https://github.com/binaural-dev/python-sdk.git
0.532   Cloning https://github.com/binaural-dev/python-sdk.git to /tmp/pip-req-build-as9j3x2w
0.533   ERROR: Error [Errno 2] No such file or directory: 'git' while executing command git version
[+] Building 0/1not find command 'git' - do you have 'git' installed and in your PATH?
 ⠏ Service odoo  Building                                                                                                                                                              528.9s
failed to solve: process "/bin/sh -c python3 -m pip install --no-cache-dir watchdog xmltodict pandas bravado_core swagger_spec_validator jsonschema==3.2.0 pdf2image xmltodict git+https://github.com/binaural-dev/python-sdk.git cryptography==35.0.0 watchdog" did not complete successfully: exit code: 1
```

Solución: agregar git en las dependencias a instalar en el dockerfile.