### PR TITLE
version funcional para ARM64 (mac chip M4)

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -45,3 +45,6 @@ ODOO_UPGRADE_PATH=/home/odoo/custom/odoo-upgrade
 # TRAEFIK_FRONTEND_PRIORITY=5
 # cuando se trabaje con Odoo 18,la variable POSTGRES_IMG_VERSION debe colocarse
 # en 16
+
+TRAEFIK_HOST_PORT=
+TRAEFIK_SERVICE_CONTAINER_PORT=8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,12 @@
 services:
   traefik:
     container_name: ${PROJECT_NAME}_traefik
-    image: traefik:v1.7.33-alpine
+    image: traefik:v2.10
     command:
-      - --api
-      - --docker
-      - --docker.domain=localhost
-      - --docker.exposedbydefault=false
+      - "--api.insecure=true"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
     labels:
       - traefik.enable=true
       - traefik.port=8080
@@ -15,7 +15,11 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     restart: unless-stopped
     # para que funcione la solución *.localhost
-    network_mode: "host"
+    # network_mode: "host"
+    ports:
+      - "${TRAEFIK_HOST_PORT}:${TRAEFIK_SERVICE_CONTAINER_PORT}"
+    networks:
+      - binaural
   db:
     image: postgres:${POSTGRES_IMG_VERSION}
     container_name: ${PROJECT_NAME}_db
@@ -54,6 +58,8 @@ services:
     build:
       context: .
       dockerfile: ./.resources/Dockerfile
+    ports:
+      - "${PORT_SERVICE_HOST_ODOO}:${PORT_SERVICE_CONTAINER_ODOO}"
     depends_on:
       - db
       - dns
@@ -116,6 +122,7 @@ volumes:
 
 networks:
   binaural:
+    driver: bridge
     external: false
     name: odoo-${ODOO_VERSION}
     ipam:


### PR DESCRIPTION
Cambios en docker compose:
- Para plataformas ARM64 no funciona la opcion network_mode: "host", se remueve (hay que probar que efecto tiene en linux)
- Actualizacion de traefik, se remueve la version alpine
- Se expone explicitamente el puerto al no funcionar la opcion network_mode: host

Evaluar si funciona en linux para conservar una sola rama para las 2 plataformas