### PR TITLE
Fix auto-detection of odoo-venezuela addons

### DIFF
--- a/.resources/entrypoint.d/400-auto-detect-addons
+++ b/.resources/entrypoint.d/400-auto-detect-addons
@@ -27,6 +27,11 @@ THIRD_PATH = os.path.join(SOURCES, "third-party-addons")
 if os.path.isdir(THIRD_PATH):
     addons.insert(0, os.path.join(THIRD_PATH))
 
+# Odoo Venezuela public modules
+VENEZUELA_PATH = os.path.join(SOURCES, "odoo-venezuela")
+if os.path.isdir(VENEZUELA_PATH):
+    addons.insert(0, os.path.join(VENEZUELA_PATH))
+
 # Project repositories
 repo_addons = []
 


### PR DESCRIPTION
## Summary
- include `odoo-venezuela` repository when generating `addons_path`

## Testing
- `python3 -m py_compile .resources/entrypoint.d/400-auto-detect-addons`

------
https://chatgpt.com/codex/tasks/task_b_684307796af4832fbf5a0bef7b22aea3