### PR TITLE
Add candidate test instructions

### DIFF
--- a/issues/accounting_fiscal_classification.md
+++ b/issues/accounting_fiscal_classification.md
@@ -1,0 +1,13 @@
+# Accounting: Fiscal Classification on Invoices
+
+## Goal
+Agregar un nuevo campo `fiscal_classification` de tipo selección en `account.move`. Los valores válidos serán A, B y C. Debe mostrarse en el formulario de factura y permitir búsquedas por esta clasificación.
+
+## Acceptance Tests
+- El valor por defecto de `fiscal_classification` debe ser A.
+- El campo debe mostrarse en la vista de formulario de `account.move`.
+- Debe existir un filtro de búsqueda para este campo.
+- Incluir una prueba unitaria que valide el valor por defecto y la actualización del campo.
+
+## Evaluación
+El módulo debe instalarse sin errores y las pruebas deben ejecutarse correctamente en el entorno provisto.

--- a/issues/hr_birthday_reminder.md
+++ b/issues/hr_birthday_reminder.md
@@ -1,0 +1,12 @@
+# HR: Birthday Reminder
+
+## Goal
+Crear un `cron` que envíe un recordatorio por correo siete días antes del cumpleaños del empleado.
+
+## Acceptance Tests
+- Debe existir un modelo que calcule los cumpleaños próximos y envíe el correo.
+- El `cron` debe ejecutarse diariamente.
+- Incluir una prueba unitaria para la función que envía el recordatorio.
+
+## Evaluación
+El módulo debe instalarse sin errores y contener pruebas que validen el comportamiento del `cron`.

--- a/issues/pos_table_number.md
+++ b/issues/pos_table_number.md
@@ -1,0 +1,13 @@
+# Point of Sale: Table Number
+
+## Goal
+Permitir que el cajero asigne un número de mesa a cada pedido de punto de venta. Este número debe almacenarse en el modelo de orden y mostrarse en el recibo.
+
+## Acceptance Tests
+- Agregar el campo `table_number` en el modelo de órdenes de punto de venta.
+- La interfaz debe permitir al usuario introducir el número de mesa.
+- El recibo impreso debe incluir dicho número.
+- Incluir una prueba que verifique que el campo se almacena y se muestra correctamente.
+
+## Evaluación
+El desarrollo debe seguir las guías de Odoo y contar con pruebas automatizadas.

--- a/issues/sales_warranty_months.md
+++ b/issues/sales_warranty_months.md
@@ -1,0 +1,13 @@
+# Sales: Warranty Months
+
+## Goal
+Añadir un campo `warranty_months` en los productos que indique la cantidad de meses de garantía. Este valor debe copiarse a las líneas de la orden de venta y mostrarse en el reporte de presupuesto.
+
+## Acceptance Tests
+- El campo `warranty_months` debe estar disponible en `product.template` y `product.product`.
+- Al crear una orden de venta, el valor debe propagarse a las líneas de venta.
+- El reporte de la orden de venta debe mostrar dicho valor.
+- Incluir una prueba que verifique la propagación correcta del campo.
+
+## Evaluación
+El código debe seguir las convenciones de Odoo y contar con pruebas automáticas exitosas.

--- a/issues/stock_quality_check.md
+++ b/issues/stock_quality_check.md
@@ -1,0 +1,12 @@
+# Stock: Quality Check on Transfers
+
+## Goal
+Implementar una verificación de calidad opcional al validar albaranes. Al transferir, debe aparecer un asistente para registrar si la mercancía aprueba o falla.
+
+## Acceptance Tests
+- Si la verificación está activada, el picking no puede completarse sin registrar el resultado.
+- El asistente debe permitir indicar aprobación o rechazo.
+- Incluir pruebas que aseguren que la transferencia se bloquea hasta completar la verificación.
+
+## Evaluación
+El código debe incluir pruebas automáticas y respetar las buenas prácticas de Odoo.

--- a/readme.md
+++ b/readme.md
@@ -142,3 +142,17 @@ Cada vez que añades un nuevo repositorio a la carpeta custom, este será autom�
 Para entender completamente el funcionamiento del entorno, te recomendamos familiarizarte con los comandos de la terminal de Linux, Docker, Traefik y, por supuesto, Odoo.
 
 Si tienes alguna pregunta, no dudes en contactar con el equipo. Si no eres parte del equipo de desarrollo de Binaural, por favor utiliza los Issues en GitHub (siguiendo el código de conducta establecido).
+
+### Ejecución de pruebas
+
+Una vez construido el entorno con `./odoo build` y en ejecución con `./odoo run`, las pruebas automáticas pueden ejecutarse en una base de datos temporal (por ejemplo `testing`). El nombre del contenedor está definido por la variable `PROJECT_NAME` en el `.env`.
+
+```bash
+docker exec -u odoo -it ${PROJECT_NAME} odoo -d testing -i <tu_modulo> --test-enable --without-demo=true --stop-after-init -c /home/odoo/.config/odoo.conf
+```
+
+Reemplaza `<tu_modulo>` con el módulo que hayas desarrollado para la prueba.
+
+### Ejercicios propuestos
+
+En el directorio `issues/` se incluyen ejemplos de funcionalidades de prueba para candidatos. Cada archivo describe la meta, los criterios de aceptación y las pruebas requeridas. Selecciona uno de ellos y desarrolla la solución siguiendo las pautas indicadas.


### PR DESCRIPTION
## Summary
- document how to run tests inside the Docker environment
- add sample candidate issues for accounting, sales, hr, stock and PoS

## Testing
- `./scripts/odoo-test` *(fails: `docker: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68472add0678832fb01dd4088601d241