### PR TITLE
feat: add support for odoo 14

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -2,7 +2,9 @@ PROJECT_NAME=proj
 PORT_SERVICE_HOST_ODOO=80
 PORT_SERVICE_CONTAINER_ODOO=8069
 ODOO_RELEASE=latest
+# Define la versión de Odoo a utilizar (p.ej. 14.0, 16.0, 17.0, 18.0)
 ODOO_VERSION=16.0
+# Utiliza el número menor correspondiente a la versión (14, 16, 17, 18)
 ODOO_MINOR=16
 POSTGRES_IMG_VERSION=14
 POSTGRES_DB=postgres

--- a/.resources/dockerfiles/14.0_Dockerfile
+++ b/.resources/dockerfiles/14.0_Dockerfile
@@ -1,0 +1,65 @@
+FROM debian:bullseye-slim
+ENV LANG C.UTF-8
+USER root
+
+# Enable Odoo user and filestore
+RUN useradd -md /home/odoo -s /bin/false odoo \
+    && mkdir -p /var/lib/odoo \
+    && chown -R odoo:odoo /var/lib/odoo \
+    && sync
+
+# Install dependencies and wkhtmltopdf
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        dirmngr \
+        fonts-noto-cjk \
+        gnupg \
+        libssl-dev \
+        node-less \
+        npm \
+        python3-num2words \
+        python3-pdfminer \
+        python3-pip \
+        python3-phonenumbers \
+        python3-pyldap \
+        python3-qrcode \
+        python3-renderpm \
+        python3-setuptools \
+        python3-slugify \
+        python3-vobject \
+        python3-watchdog \
+        python3-xlrd \
+        python3-xlwt \
+        python3-dev \
+        python3-pandas \
+        xz-utils \
+    && curl -o wkhtmltox.deb -sSL https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.buster_amd64.deb \
+    && echo 'ea8277df4297afc507c61122f3c349af142f31e5 wkhtmltox.deb' | sha1sum -c - \
+    && apt-get install -y --no-install-recommends ./wkhtmltox.deb \
+    && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
+
+# install latest postgresql-client
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
+    && GNUPGHOME="$(mktemp -d)" \
+    && gpg --batch --keyserver keyserver.ubuntu.com --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
+    && gpg --batch --armor --export B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 > /etc/apt/trusted.gpg.d/pgdg.gpg.asc \
+    && gpgconf --kill all \
+    && rm -rf "$GNUPGHOME" \
+    && apt-get update \
+    && apt-get install --no-install-recommends -y postgresql-client \
+    && rm -f /etc/apt/sources.list.d/pgdg.list \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install rtlcss and Python packages
+RUN npm install -g rtlcss \
+    && pip3 install num2words xlwt xlrd openpyxl pytest-odoo pandas wheel html2text bcrypt cairosvg
+
+# Install Odoo
+ARG ODOO_VERSION
+ARG ODOO_RELEASE
+RUN curl -o odoo.deb -sSL http://nightly.odoo.com/14.0/nightly/deb/odoo_14.0.${ODOO_RELEASE}_all.deb \
+    && apt-get update \
+    && apt-get -y install --no-install-recommends ./odoo.deb \
+    && rm -rf /var/lib/apt/lists/* odoo.deb

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,8 @@
 
 Binaural Workspace es un entorno de desarrollo diseñado para facilitar la ejecución y configuración de proyectos en Odoo. Con este repositorio, podrás levantar ambientes de desarrollo en Linux y macOS (AMD y ARM).
 
+Es compatible con las versiones 14.0, 16.0, 17.0 y 18.0 de Odoo, permitiéndote elegir la que mejor se adapte a tu proyecto.
+
 En cuanto a Windows, no se ha probado oficialmente, pero puede ser compatible utilizando WSL2 con Docker. Se recomienda verificar su funcionamiento en tu entorno antes de usarlo en producción.
 
 ## Instalación
@@ -40,7 +42,7 @@ Para trabajar con la configuración por defecto, puedes ejecutar el siguiente co
 cp .env_example .env
 ```
 
-> El .env_example está creado para levantar la versión 16.0 de Odoo. En caso de requerir una versión diferente, puedes cambiar el archivo .env actualizandos las referencias de 16.0 a 17.0.
+> El `.env_example` está creado para levantar la versión 16.0 de Odoo. Si necesitas otra versión (como 14.0, 17.0 o 18.0), actualiza el archivo `.env` reemplazando las referencias por la versión deseada.
 
 ### Descripción de los campos de `.env_example`
 


### PR DESCRIPTION
## Summary
- add Dockerfile for Odoo 14 builds
- document version selection and Odoo 14 support

## Testing
- `python3 -m py_compile odoo`
- `./odoo build --no-cache` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_b_68921694c050832fbda3e6abc3c65d9e