### PR TITLE
FEAT: .env_example, odoo

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -18,8 +18,9 @@ RESET_PASSWORD=admin
 PGDATABASE=postgres
 RESET_PASSWORD=admin
 
-#Valid values are "binaural" "external"
+#Valid values are "binaural","external","enterprise"
 ENV_TYPE=external
+ORG_NAME=binaural-dev
 
 #DBFILTER='%d.*$'
 DOMAIN={catchall:.*}

--- a/odoo
+++ b/odoo
@@ -176,7 +176,7 @@ def build_odoo(no_cache):
 
 
 def init_addons():
-    ORG_NAME = os.getenv("ORG_NAME")
+    ORG_NAME = os.getenv("ORG_NAME") or "binaural-dev"
     required_sources = {
         "binaural": [
             f"{ORG_NAME}/enterprise",

--- a/odoo
+++ b/odoo
@@ -176,15 +176,16 @@ def build_odoo(no_cache):
 
 
 def init_addons():
+    ORG_NAME = os.getenv("ORG_NAME")
     required_sources = {
         "binaural": [
-            "binaural-dev/enterprise",
-            "binaural-dev/integra-addons",
-            "binaural-dev/third-party-addons",
-            "binaural-dev/odoo-venezuela",
+            f"{ORG_NAME}/enterprise",
+            f"{ORG_NAME}/integra-addons",
+            f"{ORG_NAME}/third-party-addons",
+            f"{ORG_NAME}/odoo-venezuela",
         ],
-        "external": ["binaural-dev/odoo-venezuela"],
-        "enterprise": ["binaural-dev/enterprise"],
+        "external": [f"{ORG_NAME}/odoo-venezuela"],
+        "enterprise": [f"{ORG_NAME}/enterprise"],
     }
     ENV_TYPE = os.getenv("ENV_TYPE")
     print("Clonando Repositorios")


### PR DESCRIPTION
[FIX] 2doce_scale: corrige error _super en patch de barcode de báscula y agrega extracción de peso

## ¿Por qué?
El patch de barcode de báscula TM-xA en `pos_barcode_patch.js` fallaba con `TypeError: this._super is not a function` en staging. Investigando, descubrimos que otro módulo (`om_datalogic`) ya parcheaba `ProductScreen._getProductByBarcode` antes que nosotros, rompiendo la cadena de `_super` de Odoo 17. Además, el código no extraía el peso del barcode escaneado, por lo que el producto se agregaba al POS con cantidad 1 en lugar del peso real.

## ¿Qué cambia?
- `static/src/js/pos_barcode_patch.js`:
  - **Fix crítico de `_super`**: Reemplaza `patch() + this._super` por monkey-patching directo con retry. Captura `ProductScreen.prototype._getProductByBarcode` en tiempo de ejecución (con `setTimeout` hasta que esté disponible), guarda la referencia original y sobreescribe el método. Esto hace el patch robusto contra cualquier otro módulo que parchee el mismo método antes.
  - Extrae el peso de las posiciones 7-11 del barcode, divide por 1000 y setea `code.type='weight'` y `code.value=kg` para que Odoo POS agregue el producto con la cantidad correcta automáticamente.
  - Corrige el guard de longitud de barcode a `>= 12`.
- `data/server_actions.xml`:
  - Nueva acción de servidor "Recompute Scale Barcodes" en `product.template` para recalcular `barcode_scale` en productos importados por Excel que tienen `plu_id` pero el campo computado no se pobló.
- `__manifest__.py`:
  - Agrega dependencia `point_of_sale`.
  - Agrega assets de tours en `point_of_sale._assets_pos`.
  - Incluye `data/server_actions.xml`.
- `tests/__init__.py`:
  - Importa `test_pos_scale_barcode`.
- `tests/test_pos_scale_barcode.py`:
  - Nuevos tests `TransactionCase` que validan: campos de producto, formato de barcode, carga de POS session, asset bundle, y existencia de archivos de tour.
- `static/tests/tours/test_pos_scale_barcode.js`:
  - Tour manual para validación en navegador del escaneo de barcodes de báscula.
- `TESTING.md`:
  - Documentación del método de prueba manual vía `simulateBarcodeScan()` en consola del navegador.

## ¿Cómo se probó?
- [x] Update del módulo en DB local
- [x] Tests unitarios pasan: `odoo --test-tags /2doce_scale:TestPOSScaleBarcode` → 7/7 tests OK
- [ ] Cobertura >= umbral definido

## References
- Ticket: none
- Tarea: none

## Notas de auditoría
- El controller `download_products_plu_tmxa` en `controllers/main.py` fue identificado con una vulnerabilidad **pre-existente** de fuga de datos multi-compañía (validación ausente de `company_id`). **No está incluido en este PR** para mantener el scope. Recomendación: trackear en ticket separado.
- Se descartó usar `barcode.nomenclature` nativo de Odoo porque el parser solo soporta un bloque numérico y el formato TM-xA requiere PLU + peso separados.