### PR TITLE
Ajuste faltantes en .env_example

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -27,7 +27,7 @@ ADMIN_PASSWORD=admin
 # Postgres version to use (14, 16 -> para Odoo 18 y 19)
 POSTGRES_IMG_VERSION=16
 POSTGRES_DB=postgres
-POSTGRES_HOST=db
+POSTGRES_HOST=host.docker.internal
 POSTGRES_PASSWORD=odoo
 POSTGRES_USER=odoo
 PGDATABASE=postgres
@@ -68,7 +68,7 @@ WORKERS=2   # balance entre CPU y RAM
 LIMIT_MEMORY_SOFT=16000000000    # ~16 GB
 LIMIT_MEMORY_HARD=17000000000    # ~17 GB
 
-MAX_CRON_THREADS=0
+MAX_CRON_THREADS=1
 
 # Tiempo máximo de ejecución por transacción
 LIMIT_TIME_REAL_CRON=0


### PR DESCRIPTION
Agregue max cron threads 1 enves de 0 para que se ejecuten los crons.

y POSTGRES_HOST=host.docker.internal

para habilitar el uso de diferentes docker odoo en una misma maquina.