### PR TITLE
feat(tui): enabled toggle, fzf module picker, consolidated update flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env
 instances.json
 src
+!mcp-server/src
 .resources/Dockerfile
 .resources/Dockerfile.*
 !.resources/Dockerfile.template

--- a/.resources/generators/config_loader.py
+++ b/.resources/generators/config_loader.py
@@ -31,6 +31,38 @@ def load_config(base_path):
     return config
 
 
+def load_full_config(base_path):
+    """Load instances.json from the project root WITHOUT filtering.
+
+    Use this when the caller needs to see / toggle the ``enabled`` flag
+    (e.g. the interactive TUI). For dispatch paths (./odoo CLI, generators)
+    prefer :func:`load_config`, which enforces the enabled filter.
+
+    The same validation as ``load_config`` is applied to the unfiltered
+    structure so that downstream resolvers don't see inconsistent data.
+    """
+    config_path = os.path.join(base_path, "instances.json")
+    if not os.path.exists(config_path):
+        print(f"Error: instances.json no encontrado en {base_path}")
+        print("Copia instances.example.json a instances.json y configúralo.")
+        sys.exit(1)
+
+    with open(config_path, "r") as f:
+        config = json.load(f)
+
+    _validate_config(config)
+    return config
+
+
+def is_instance_enabled(inst_conf) -> bool:
+    """Return whether an instance config block is enabled.
+
+    Defaults to ``True`` when the flag is missing, matching the behaviour
+    of :func:`load_config`.
+    """
+    return inst_conf.get("enabled", True)
+
+
 def _validate_config(config):
     """Validate the configuration structure."""
     required_sections = ["odoo_configs", "databases", "instances"]

--- a/instances.example.json
+++ b/instances.example.json
@@ -76,6 +76,19 @@
           "src/custom/client-b"
         ]
       }
+    },
+    "client-paused": {
+      "enabled": false,
+      "odoo_version": "19.0",
+      "external_port": 8072,
+      "database": "pg16",
+      "odoo_config": "19.0_default",
+      "overwrite_odoo_config": {
+        "addons": [
+          "src/enterprise",
+          "src/custom/client-paused"
+        ]
+      }
     }
   },
   "pgadmin": {

--- a/mcp-server/.gitignore
+++ b/mcp-server/.gitignore
@@ -1,0 +1,10 @@
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+dist/
+build/
+.pytest_cache/
+.coverage
+htmlcov/

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,79 @@
+# Odoo MCP Server
+
+MCP Server for Multi-Instance Odoo Docker - provides SQL and ORM access to Odoo databases for AI agents.
+
+## Features
+
+- **Discovery**: List instances, databases, and get instance info
+- **SQL**: Direct PostgreSQL queries (SELECT, INSERT, UPDATE, DELETE)
+- **Odoo ORM**: XML-RPC access to Odoo models (search_read, fields_get, count, create, write)
+- **Read-only by default**: Write operations require `ALLOW_WRITE=true`
+
+## Installation
+
+```bash
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -e .
+```
+
+## Usage
+
+### As MCP Server (via OpenCode)
+
+Add to `opencode.json`:
+
+```json
+{
+  "mcp": {
+    "odoo-db": {
+      "type": "local",
+      "command": ["/path/to/mcp-server/.venv/bin/python", "-m", "odoo_mcp_server"],
+      "env": {
+        "INSTANCES_JSON": "/path/to/multi-docker-odoo/instances.json",
+        "ALLOW_WRITE": "false"
+      }
+    }
+  }
+}
+```
+
+### CLI Testing
+
+```bash
+# Test configuration
+python -m odoo_mcp_server --instances-json /path/to/instances.json --test
+
+# List instances
+python -m odoo_mcp_server --instances-json /path/to/instances.json --list-instances
+```
+
+## Tools
+
+### Discovery
+- `list_instances()` - List all configured Odoo instances
+- `list_databases()` - List all configured PostgreSQL databases
+- `instance_info(instance_name)` - Get detailed instance information
+
+### SQL
+- `sql_query(database, dbname, query, limit)` - Execute SELECT queries
+- `sql_tables(database, dbname, schema)` - List tables in a schema
+- `sql_describe(database, dbname, table, schema)` - Describe table structure
+- `sql_databases_list(database)` - List PostgreSQL databases
+- `sql_execute(database, dbname, query)` - Execute write queries (requires ALLOW_WRITE=true)
+
+### Odoo ORM
+- `odoo_search_read(instance, dbname, model, domain, fields, limit, offset, order, username, password)` - Search and read records
+- `odoo_fields_get(instance, dbname, model, username, password)` - Get model fields
+- `odoo_count(instance, dbname, model, domain, username, password)` - Count records
+- `odoo_create(instance, dbname, model, values, username, password)` - Create records (requires ALLOW_WRITE=true)
+- `odoo_write(instance, dbname, model, record_ids, values, username, password)` - Update records (requires ALLOW_WRITE=true)
+
+## Environment Variables
+
+- `INSTANCES_JSON` - Path to instances.json
+- `ALLOW_WRITE` - Enable write operations (default: false)
+
+## License
+
+MIT

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "odoo-mcp-server"
+version = "0.1.0"
+description = "MCP Server for Multi-Instance Odoo Docker - provides SQL and ORM access to Odoo databases"
+readme = "README.md"
+requires-python = ">=3.10"
+license = "MIT"
+authors = [
+    { name = "Binaural Dev Team" }
+]
+dependencies = [
+    "mcp>=1.0.0",
+    "psycopg2-binary>=2.9.9",
+]
+
+[project.scripts]
+odoo-mcp-server = "odoo_mcp_server.__main__:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/odoo_mcp_server"]
+
+[tool.hatch.build.targets.wheel.sources]
+"src" = ""
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/mcp-server/src/odoo_mcp_server/__init__.py
+++ b/mcp-server/src/odoo_mcp_server/__init__.py
@@ -1,0 +1,5 @@
+"""
+Odoo MCP Server - Provides SQL and ORM access to Odoo databases for AI agents.
+"""
+
+__version__ = "0.1.0"

--- a/mcp-server/src/odoo_mcp_server/__main__.py
+++ b/mcp-server/src/odoo_mcp_server/__main__.py
@@ -1,0 +1,86 @@
+"""
+Entry point for the Odoo MCP Server.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+from .config import Config
+from .server import create_server
+from . import discovery_tools
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Odoo Multi-Instance MCP Server")
+    parser.add_argument(
+        "--instances-json",
+        default=os.environ.get("INSTANCES_JSON"),
+        help="Path to instances.json (default: $INSTANCES_JSON env var)",
+    )
+    parser.add_argument(
+        "--allow-write",
+        action="store_true",
+        default=os.environ.get("ALLOW_WRITE", "false").lower() == "true",
+        help="Enable write operations (default: $ALLOW_WRITE env var)",
+    )
+    parser.add_argument(
+        "--test",
+        action="store_true",
+        help="Run in test mode - verify connection and exit",
+    )
+    parser.add_argument(
+        "--list-instances",
+        action="store_true",
+        help="List configured instances and exit",
+    )
+
+    args = parser.parse_args()
+
+    if not args.instances_json:
+        print("Error: --instances-json or INSTANCES_JSON env var required", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        config = Config(args.instances_json)
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error loading config: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.list_instances:
+        result = discovery_tools.list_instances(config)
+        print(result)
+        sys.exit(0)
+
+    if args.test:
+        print("Testing configuration...")
+        print(f"  instances.json: {args.instances_json}")
+        print(f"  allow_write: {args.allow_write}")
+        print(f"  instances: {len(config.get_instances())}")
+        print(f"  databases: {len(config.get_databases())}")
+
+        instances = config.get_instances()
+        if instances:
+            print("\nConfigured instances:")
+            for name, inst in sorted(instances.items()):
+                print(f"  - {name}: Odoo {inst.odoo_version} @ http://localhost:{inst.external_port} (db: {inst.database})")
+
+        databases = config.get_databases()
+        if databases:
+            print("\nConfigured databases:")
+            for name, db in sorted(databases.items()):
+                print(f"  - {name}: PostgreSQL {db.postgres_version} @ {db.host}:{db.port}")
+
+        print("\nConfiguration OK")
+        sys.exit(0)
+
+    mcp = create_server(config, allow_write=args.allow_write)
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp-server/src/odoo_mcp_server/config.py
+++ b/mcp-server/src/odoo_mcp_server/config.py
@@ -1,0 +1,117 @@
+"""
+Configuration loader for instances.json.
+Provides structured access to Odoo instances, databases, and connection info.
+"""
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+
+@dataclass
+class DatabaseConfig:
+    name: str
+    postgres_version: int
+    port: int
+    user: str
+    password: str
+    host: str = "localhost"
+    create_container: bool = True
+    config: Optional[str] = None
+
+
+@dataclass
+class InstanceConfig:
+    name: str
+    odoo_version: str
+    external_port: int
+    database: str
+    odoo_config: str
+    addons: List[str]
+    enabled: bool = True
+
+
+class Config:
+    def __init__(self, instances_json_path: str):
+        self.instances_json_path = instances_json_path
+        self._data = None
+        self._databases: Dict[str, DatabaseConfig] = {}
+        self._instances: Dict[str, InstanceConfig] = {}
+        self._load()
+
+    def _load(self):
+        if not os.path.exists(self.instances_json_path):
+            raise FileNotFoundError(f"instances.json not found at {self.instances_json_path}")
+
+        with open(self.instances_json_path, "r") as f:
+            self._data = json.load(f)
+
+        self._parse_databases()
+        self._parse_instances()
+
+    def _parse_databases(self):
+        for db_name, db_conf in self._data.get("databases", {}).items():
+            self._databases[db_name] = DatabaseConfig(
+                name=db_name,
+                postgres_version=db_conf["postgres_version"],
+                port=db_conf["port"],
+                user=db_conf["user"],
+                password=db_conf["password"],
+                host=db_conf.get("host", "localhost"),
+                create_container=db_conf.get("create_container", True),
+                config=db_conf.get("config"),
+            )
+
+    def _parse_instances(self):
+        for inst_name, inst_conf in self._data.get("instances", {}).items():
+            if not inst_conf.get("enabled", True):
+                continue
+
+            odoo_config_name = inst_conf["odoo_config"]
+            odoo_config = self._data.get("odoo_configs", {}).get(odoo_config_name, {})
+
+            overwrite = inst_conf.get("overwrite_odoo_config", {})
+            merged_config = {**odoo_config, **overwrite}
+
+            self._instances[inst_name] = InstanceConfig(
+                name=inst_name,
+                odoo_version=inst_conf["odoo_version"],
+                external_port=inst_conf["external_port"],
+                database=inst_conf["database"],
+                odoo_config=odoo_config_name,
+                addons=merged_config.get("addons", []),
+                enabled=inst_conf.get("enabled", True),
+            )
+
+    def get_databases(self) -> Dict[str, DatabaseConfig]:
+        return self._databases
+
+    def get_database(self, name: str) -> Optional[DatabaseConfig]:
+        return self._databases.get(name)
+
+    def get_instances(self) -> Dict[str, InstanceConfig]:
+        return self._instances
+
+    def get_instance(self, name: str) -> Optional[InstanceConfig]:
+        return self._instances.get(name)
+
+    def get_instance_by_db(self, db_name: str) -> List[InstanceConfig]:
+        return [inst for inst in self._instances.values() if inst.database == db_name]
+
+    def get_odoo_url(self, instance_name: str) -> str:
+        inst = self.get_instance(instance_name)
+        if not inst:
+            raise ValueError(f"Instance '{instance_name}' not found")
+        return f"http://localhost:{inst.external_port}"
+
+    def get_db_connection_params(self, db_name: str) -> Dict:
+        db = self.get_database(db_name)
+        if not db:
+            raise ValueError(f"Database '{db_name}' not found")
+        return {
+            "host": db.host,
+            "port": db.port,
+            "user": db.user,
+            "password": db.password,
+        }

--- a/mcp-server/src/odoo_mcp_server/db_tools.py
+++ b/mcp-server/src/odoo_mcp_server/db_tools.py
@@ -1,0 +1,202 @@
+"""
+SQL tools - direct PostgreSQL query execution.
+"""
+
+import json
+from typing import Any, Dict, List, Optional
+
+import psycopg2
+from psycopg2.extras import RealDictCursor
+
+from .config import Config
+
+
+def _get_connection(config: Config, database: str, dbname: str):
+    params = config.get_db_connection_params(database)
+    return psycopg2.connect(
+        host=params["host"],
+        port=params["port"],
+        user=params["user"],
+        password=params["password"],
+        dbname=dbname,
+    )
+
+
+def sql_query(config: Config, database: str, dbname: str, query: str, limit: int = 100) -> str:
+    """Execute a SELECT query against a PostgreSQL database.
+
+    Args:
+        database: Database config name from instances.json (e.g., 'pg16')
+        dbname: Actual PostgreSQL database name to connect to
+        query: SQL SELECT query to execute
+        limit: Maximum number of rows to return (default: 100)
+    """
+    query = query.strip()
+
+    if not query.upper().startswith("SELECT") and not query.upper().startswith("WITH"):
+        return "Error: Only SELECT and WITH queries are allowed in read-only mode. Use sql_execute for write operations."
+
+    try:
+        conn = _get_connection(config, database, dbname)
+        try:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute(query)
+                rows = cur.fetchmany(limit)
+                total = cur.rowcount if cur.rowcount >= 0 else len(rows)
+
+                result = {
+                    "rows": [dict(row) for row in rows],
+                    "row_count": len(rows),
+                    "total": total,
+                    "truncated": len(rows) < total,
+                }
+
+                return json.dumps(result, indent=2, default=str)
+        finally:
+            conn.close()
+    except psycopg2.Error as e:
+        return f"Database error: {e}"
+    except Exception as e:
+        return f"Error: {e}"
+
+
+def sql_tables(config: Config, database: str, dbname: str, schema: str = "public") -> str:
+    """List all tables in a PostgreSQL database schema.
+
+    Args:
+        database: Database config name from instances.json (e.g., 'pg16')
+        dbname: Actual PostgreSQL database name to connect to
+        schema: Schema name (default: 'public')
+    """
+    try:
+        conn = _get_connection(config, database, dbname)
+        try:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute("""
+                    SELECT table_name
+                    FROM information_schema.tables
+                    WHERE table_schema = %s
+                    ORDER BY table_name
+                """, (schema,))
+
+                tables = [row["table_name"] for row in cur.fetchall()]
+                return json.dumps({"schema": schema, "tables": tables, "count": len(tables)}, indent=2)
+        finally:
+            conn.close()
+    except psycopg2.Error as e:
+        return f"Database error: {e}"
+
+
+def sql_describe(config: Config, database: str, dbname: str, table: str, schema: str = "public") -> str:
+    """Describe the structure of a PostgreSQL table (columns, types, constraints).
+
+    Args:
+        database: Database config name from instances.json (e.g., 'pg16')
+        dbname: Actual PostgreSQL database name to connect to
+        table: Table name to describe
+        schema: Schema name (default: 'public')
+    """
+    try:
+        conn = _get_connection(config, database, dbname)
+        try:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute("""
+                    SELECT
+                        c.column_name,
+                        c.data_type,
+                        c.character_maximum_length,
+                        c.is_nullable,
+                        c.column_default,
+                        CASE WHEN pk.column_name IS NOT NULL THEN true ELSE false END as is_primary_key
+                    FROM information_schema.columns c
+                    LEFT JOIN (
+                        SELECT kcu.column_name
+                        FROM information_schema.table_constraints tc
+                        JOIN information_schema.key_column_usage kcu
+                            ON tc.constraint_name = kcu.constraint_name
+                            AND tc.table_schema = kcu.table_schema
+                        WHERE tc.constraint_type = 'PRIMARY KEY'
+                            AND tc.table_schema = %s
+                            AND tc.table_name = %s
+                    ) pk ON c.column_name = pk.column_name
+                    WHERE c.table_schema = %s AND c.table_name = %s
+                    ORDER BY c.ordinal_position
+                """, (schema, table, schema, table))
+
+                columns = [dict(row) for row in cur.fetchall()]
+
+                if not columns:
+                    return f"Table '{schema}.{table}' not found."
+
+                return json.dumps({
+                    "table": f"{schema}.{table}",
+                    "columns": columns,
+                    "column_count": len(columns),
+                }, indent=2, default=str)
+        finally:
+            conn.close()
+    except psycopg2.Error as e:
+        return f"Database error: {e}"
+
+
+def sql_execute(config: Config, database: str, dbname: str, query: str, allow_write: bool = False) -> str:
+    """Execute a write SQL query (INSERT, UPDATE, DELETE) against a PostgreSQL database.
+
+    WARNING: This modifies data. Only available when ALLOW_WRITE=true.
+
+    Args:
+        database: Database config name from instances.json (e.g., 'pg16')
+        dbname: Actual PostgreSQL database name to connect to
+        query: SQL query to execute (INSERT, UPDATE, DELETE, DDL)
+        allow_write: Whether write operations are allowed (set by env var)
+    """
+    if not allow_write:
+        return "Error: Write operations are disabled. Set ALLOW_WRITE=true to enable."
+
+    try:
+        conn = _get_connection(config, database, dbname)
+        try:
+            with conn.cursor() as cur:
+                cur.execute(query)
+                affected = cur.rowcount
+                conn.commit()
+
+                return json.dumps({
+                    "status": "success",
+                    "rows_affected": affected,
+                    "query": query,
+                }, indent=2)
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+    except psycopg2.Error as e:
+        return f"Database error: {e}"
+    except Exception as e:
+        return f"Error: {e}"
+
+
+def sql_databases_list(config: Config, database: str) -> str:
+    """List all PostgreSQL databases available on a database server.
+
+    Args:
+        database: Database config name from instances.json (e.g., 'pg16')
+    """
+    try:
+        conn = _get_connection(config, database, "postgres")
+        try:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute("""
+                    SELECT datname
+                    FROM pg_database
+                    WHERE datistemplate = false
+                    ORDER BY datname
+                """)
+
+                databases = [row["datname"] for row in cur.fetchall()]
+                return json.dumps({"databases": databases, "count": len(databases)}, indent=2)
+        finally:
+            conn.close()
+    except psycopg2.Error as e:
+        return f"Database error: {e}"

--- a/mcp-server/src/odoo_mcp_server/discovery_tools.py
+++ b/mcp-server/src/odoo_mcp_server/discovery_tools.py
@@ -1,0 +1,74 @@
+"""
+Discovery tools - list instances, databases, and get instance info.
+"""
+
+import json
+from typing import Dict, List
+
+from .config import Config
+
+
+def list_instances(config: Config) -> str:
+    """List all configured Odoo instances with their version, port, and database."""
+    instances = config.get_instances()
+    if not instances:
+        return "No instances configured."
+
+    result = []
+    for name, inst in sorted(instances.items()):
+        result.append({
+            "name": name,
+            "odoo_version": inst.odoo_version,
+            "external_port": inst.external_port,
+            "database": inst.database,
+            "url": f"http://localhost:{inst.external_port}",
+        })
+
+    return json.dumps(result, indent=2)
+
+
+def list_databases(config: Config) -> str:
+    """List all configured PostgreSQL databases."""
+    databases = config.get_databases()
+    if not databases:
+        return "No databases configured."
+
+    result = []
+    for name, db in sorted(databases.items()):
+        result.append({
+            "name": name,
+            "postgres_version": db.postgres_version,
+            "host": db.host,
+            "port": db.port,
+            "user": db.user,
+            "create_container": db.create_container,
+        })
+
+    return json.dumps(result, indent=2)
+
+
+def instance_info(config: Config, instance_name: str) -> str:
+    """Get detailed information about a specific Odoo instance."""
+    inst = config.get_instance(instance_name)
+    if not inst:
+        available = ", ".join(sorted(config.get_instances().keys()))
+        return f"Instance '{instance_name}' not found. Available: {available}"
+
+    db = config.get_database(inst.database)
+
+    info = {
+        "name": inst.name,
+        "odoo_version": inst.odoo_version,
+        "external_port": inst.external_port,
+        "url": f"http://localhost:{inst.external_port}",
+        "database": {
+            "name": inst.database,
+            "host": db.host if db else "unknown",
+            "port": db.port if db else "unknown",
+            "user": db.user if db else "unknown",
+        },
+        "odoo_config": inst.odoo_config,
+        "addons": inst.addons,
+    }
+
+    return json.dumps(info, indent=2)

--- a/mcp-server/src/odoo_mcp_server/odoo_tools.py
+++ b/mcp-server/src/odoo_mcp_server/odoo_tools.py
@@ -1,0 +1,221 @@
+"""
+Odoo ORM tools - XML-RPC access to Odoo instances.
+"""
+
+import json
+import xmlrpc.client
+from typing import Any, Dict, List, Optional
+
+from .config import Config
+
+
+def _get_odoo_connection(config: Config, instance: str, dbname: str, username: str = "admin", password: str = "admin"):
+    url = config.get_odoo_url(instance)
+    common = xmlrpc.client.ServerProxy(f"{url}/xmlrpc/2/common")
+    uid = common.authenticate(dbname, username, password, {})
+    if not uid:
+        raise ValueError(f"Failed to authenticate with Odoo instance '{instance}' on database '{dbname}'")
+    models = xmlrpc.client.ServerProxy(f"{url}/xmlrpc/2/object")
+    return uid, password, dbname, models
+
+
+def odoo_search_read(
+    config: Config,
+    instance: str,
+    dbname: str,
+    model: str,
+    domain: Optional[List] = None,
+    fields: Optional[List[str]] = None,
+    limit: int = 100,
+    offset: int = 0,
+    order: Optional[str] = None,
+    username: str = "admin",
+    password: str = "admin",
+) -> str:
+    """Search and read records from an Odoo model via XML-RPC.
+
+    Args:
+        instance: Instance name from instances.json (e.g., 'gno', 'idv')
+        dbname: PostgreSQL database name to query
+        model: Odoo model name (e.g., 'res.partner', 'sale.order')
+        domain: Odoo domain filter (e.g., [['state', '=', 'draft']])
+        fields: List of field names to retrieve
+        limit: Maximum number of records (default: 100)
+        offset: Number of records to skip
+        order: Order by field (e.g., 'name asc')
+        username: Odoo username (default: 'admin')
+        password: Odoo password (default: 'admin')
+    """
+    try:
+        uid, pwd, db, models = _get_odoo_connection(config, instance, dbname, username, password)
+
+        kwargs = {
+            "offset": offset,
+            "limit": limit,
+        }
+        if fields:
+            kwargs["fields"] = fields
+        if order:
+            kwargs["order"] = order
+
+        records = models.execute_kw(db, uid, pwd, model, "search_read", [domain or []], kwargs)
+
+        return json.dumps({
+            "model": model,
+            "records": records,
+            "count": len(records),
+            "limit": limit,
+            "offset": offset,
+        }, indent=2, default=str)
+    except Exception as e:
+        return f"Error: {e}"
+
+
+def odoo_fields_get(
+    config: Config,
+    instance: str,
+    dbname: str,
+    model: str,
+    username: str = "admin",
+    password: str = "admin",
+) -> str:
+    """Get all fields definition of an Odoo model.
+
+    Args:
+        instance: Instance name from instances.json (e.g., 'gno', 'idv')
+        dbname: PostgreSQL database name
+        model: Odoo model name (e.g., 'res.partner', 'sale.order')
+        username: Odoo username (default: 'admin')
+        password: Odoo password (default: 'admin')
+    """
+    try:
+        uid, pwd, db, models = _get_odoo_connection(config, instance, dbname, username, password)
+
+        fields = models.execute_kw(
+            db, uid, pwd, model, "fields_get", [],
+            {"attributes": ["string", "type", "help", "required", "readonly", "searchable", "sortable"]}
+        )
+
+        return json.dumps({
+            "model": model,
+            "fields": fields,
+            "field_count": len(fields),
+        }, indent=2, default=str)
+    except Exception as e:
+        return f"Error: {e}"
+
+
+def odoo_count(
+    config: Config,
+    instance: str,
+    dbname: str,
+    model: str,
+    domain: Optional[List] = None,
+    username: str = "admin",
+    password: str = "admin",
+) -> str:
+    """Count records in an Odoo model.
+
+    Args:
+        instance: Instance name from instances.json (e.g., 'gno', 'idv')
+        dbname: PostgreSQL database name
+        model: Odoo model name (e.g., 'res.partner', 'sale.order')
+        domain: Odoo domain filter (e.g., [['state', '=', 'draft']])
+        username: Odoo username (default: 'admin')
+        password: Odoo password (default: 'admin')
+    """
+    try:
+        uid, pwd, db, models = _get_odoo_connection(config, instance, dbname, username, password)
+
+        count = models.execute_kw(db, uid, pwd, model, "search_count", [domain or []])
+
+        return json.dumps({
+            "model": model,
+            "domain": domain or [],
+            "count": count,
+        }, indent=2)
+    except Exception as e:
+        return f"Error: {e}"
+
+
+def odoo_create(
+    config: Config,
+    instance: str,
+    dbname: str,
+    model: str,
+    values: Dict[str, Any],
+    allow_write: bool = False,
+    username: str = "admin",
+    password: str = "admin",
+) -> str:
+    """Create a new record in an Odoo model via XML-RPC.
+
+    WARNING: This modifies data. Only available when ALLOW_WRITE=true.
+
+    Args:
+        instance: Instance name from instances.json (e.g., 'gno', 'idv')
+        dbname: PostgreSQL database name
+        model: Odoo model name (e.g., 'res.partner')
+        values: Dictionary of field values for the new record
+        allow_write: Whether write operations are allowed (set by env var)
+        username: Odoo username (default: 'admin')
+        password: Odoo password (default: 'admin')
+    """
+    if not allow_write:
+        return "Error: Write operations are disabled. Set ALLOW_WRITE=true to enable."
+
+    try:
+        uid, pwd, db, models = _get_odoo_connection(config, instance, dbname, username, password)
+
+        record_id = models.execute_kw(db, uid, pwd, model, "create", [values])
+
+        return json.dumps({
+            "status": "success",
+            "model": model,
+            "record_id": record_id,
+        }, indent=2)
+    except Exception as e:
+        return f"Error: {e}"
+
+
+def odoo_write(
+    config: Config,
+    instance: str,
+    dbname: str,
+    model: str,
+    record_ids: List[int],
+    values: Dict[str, Any],
+    allow_write: bool = False,
+    username: str = "admin",
+    password: str = "admin",
+) -> str:
+    """Update existing records in an Odoo model via XML-RPC.
+
+    WARNING: This modifies data. Only available when ALLOW_WRITE=true.
+
+    Args:
+        instance: Instance name from instances.json (e.g., 'gno', 'idv')
+        dbname: PostgreSQL database name
+        model: Odoo model name (e.g., 'res.partner')
+        record_ids: List of record IDs to update
+        values: Dictionary of field values to update
+        allow_write: Whether write operations are allowed (set by env var)
+        username: Odoo username (default: 'admin')
+        password: Odoo password (default: 'admin')
+    """
+    if not allow_write:
+        return "Error: Write operations are disabled. Set ALLOW_WRITE=true to enable."
+
+    try:
+        uid, pwd, db, models = _get_odoo_connection(config, instance, dbname, username, password)
+
+        result = models.execute_kw(db, uid, pwd, model, "write", [record_ids, values])
+
+        return json.dumps({
+            "status": "success",
+            "model": model,
+            "record_ids": record_ids,
+            "updated": result,
+        }, indent=2)
+    except Exception as e:
+        return f"Error: {e}"

--- a/mcp-server/src/odoo_mcp_server/server.py
+++ b/mcp-server/src/odoo_mcp_server/server.py
@@ -1,0 +1,225 @@
+"""
+MCP Server for Multi-Instance Odoo Docker.
+Provides SQL and ORM access to Odoo databases for AI agents.
+"""
+
+import os
+from typing import List, Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from .config import Config
+from . import discovery_tools
+from . import db_tools
+from . import odoo_tools
+
+
+def create_server(config: Config, allow_write: bool = False) -> FastMCP:
+    """Create and configure the MCP server with all tools."""
+
+    mcp = FastMCP(
+        "Odoo Multi-Instance MCP",
+        instructions="Provides SQL and ORM access to Odoo databases for AI agents",
+    )
+
+    # Discovery tools
+    @mcp.tool()
+    def list_instances() -> str:
+        """List all configured Odoo instances with their version, port, and database."""
+        return discovery_tools.list_instances(config)
+
+    @mcp.tool()
+    def list_databases() -> str:
+        """List all configured PostgreSQL databases."""
+        return discovery_tools.list_databases(config)
+
+    @mcp.tool()
+    def instance_info(instance_name: str) -> str:
+        """Get detailed information about a specific Odoo instance.
+
+        Args:
+            instance_name: Instance name from instances.json (e.g., 'gno', 'idv')
+        """
+        return discovery_tools.instance_info(config, instance_name)
+
+    # SQL tools
+    @mcp.tool()
+    def sql_query(database: str, dbname: str, query: str, limit: int = 100) -> str:
+        """Execute a SELECT query against a PostgreSQL database.
+
+        Args:
+            database: Database config name from instances.json (e.g., 'pg16')
+            dbname: Actual PostgreSQL database name to connect to
+            query: SQL SELECT query to execute
+            limit: Maximum number of rows to return (default: 100)
+        """
+        return db_tools.sql_query(config, database, dbname, query, limit)
+
+    @mcp.tool()
+    def sql_tables(database: str, dbname: str, schema: str = "public") -> str:
+        """List all tables in a PostgreSQL database schema.
+
+        Args:
+            database: Database config name from instances.json (e.g., 'pg16')
+            dbname: Actual PostgreSQL database name to connect to
+            schema: Schema name (default: 'public')
+        """
+        return db_tools.sql_tables(config, database, dbname, schema)
+
+    @mcp.tool()
+    def sql_describe(database: str, dbname: str, table: str, schema: str = "public") -> str:
+        """Describe the structure of a PostgreSQL table (columns, types, constraints).
+
+        Args:
+            database: Database config name from instances.json (e.g., 'pg16')
+            dbname: Actual PostgreSQL database name to connect to
+            table: Table name to describe
+            schema: Schema name (default: 'public')
+        """
+        return db_tools.sql_describe(config, database, dbname, table, schema)
+
+    @mcp.tool()
+    def sql_databases_list(database: str) -> str:
+        """List all PostgreSQL databases available on a database server.
+
+        Args:
+            database: Database config name from instances.json (e.g., 'pg16')
+        """
+        return db_tools.sql_databases_list(config, database)
+
+    if allow_write:
+        @mcp.tool()
+        def sql_execute(database: str, dbname: str, query: str) -> str:
+            """Execute a write SQL query (INSERT, UPDATE, DELETE) against a PostgreSQL database.
+
+            WARNING: This modifies data.
+
+            Args:
+                database: Database config name from instances.json (e.g., 'pg16')
+                dbname: Actual PostgreSQL database name to connect to
+                query: SQL query to execute (INSERT, UPDATE, DELETE, DDL)
+            """
+            return db_tools.sql_execute(config, database, dbname, query, allow_write=True)
+
+    # Odoo ORM tools
+    @mcp.tool()
+    def odoo_search_read(
+        instance: str,
+        dbname: str,
+        model: str,
+        domain: Optional[List] = None,
+        fields: Optional[List[str]] = None,
+        limit: int = 100,
+        offset: int = 0,
+        order: Optional[str] = None,
+        username: str = "admin",
+        password: str = "admin",
+    ) -> str:
+        """Search and read records from an Odoo model via XML-RPC.
+
+        Args:
+            instance: Instance name from instances.json (e.g., 'gno', 'idv')
+            dbname: PostgreSQL database name to query
+            model: Odoo model name (e.g., 'res.partner', 'sale.order')
+            domain: Odoo domain filter (e.g., [['state', '=', 'draft']])
+            fields: List of field names to retrieve
+            limit: Maximum number of records (default: 100)
+            offset: Number of records to skip
+            order: Order by field (e.g., 'name asc')
+            username: Odoo username (default: 'admin')
+            password: Odoo password (default: 'admin')
+        """
+        return odoo_tools.odoo_search_read(
+            config, instance, dbname, model, domain, fields, limit, offset, order, username, password
+        )
+
+    @mcp.tool()
+    def odoo_fields_get(
+        instance: str,
+        dbname: str,
+        model: str,
+        username: str = "admin",
+        password: str = "admin",
+    ) -> str:
+        """Get all fields definition of an Odoo model.
+
+        Args:
+            instance: Instance name from instances.json (e.g., 'gno', 'idv')
+            dbname: PostgreSQL database name
+            model: Odoo model name (e.g., 'res.partner', 'sale.order')
+            username: Odoo username (default: 'admin')
+            password: Odoo password (default: 'admin')
+        """
+        return odoo_tools.odoo_fields_get(config, instance, dbname, model, username, password)
+
+    @mcp.tool()
+    def odoo_count(
+        instance: str,
+        dbname: str,
+        model: str,
+        domain: Optional[List] = None,
+        username: str = "admin",
+        password: str = "admin",
+    ) -> str:
+        """Count records in an Odoo model.
+
+        Args:
+            instance: Instance name from instances.json (e.g., 'gno', 'idv')
+            dbname: PostgreSQL database name
+            model: Odoo model name (e.g., 'res.partner', 'sale.order')
+            domain: Odoo domain filter (e.g., [['state', '=', 'draft']])
+            username: Odoo username (default: 'admin')
+            password: Odoo password (default: 'admin')
+        """
+        return odoo_tools.odoo_count(config, instance, dbname, model, domain, username, password)
+
+    if allow_write:
+        @mcp.tool()
+        def odoo_create(
+            instance: str,
+            dbname: str,
+            model: str,
+            values: dict,
+            username: str = "admin",
+            password: str = "admin",
+        ) -> str:
+            """Create a new record in an Odoo model via XML-RPC.
+
+            WARNING: This modifies data.
+
+            Args:
+                instance: Instance name from instances.json (e.g., 'gno', 'idv')
+                dbname: PostgreSQL database name
+                model: Odoo model name (e.g., 'res.partner')
+                values: Dictionary of field values for the new record
+                username: Odoo username (default: 'admin')
+                password: Odoo password (default: 'admin')
+            """
+            return odoo_tools.odoo_create(config, instance, dbname, model, values, allow_write=True, username=username, password=password)
+
+        @mcp.tool()
+        def odoo_write(
+            instance: str,
+            dbname: str,
+            model: str,
+            record_ids: List[int],
+            values: dict,
+            username: str = "admin",
+            password: str = "admin",
+        ) -> str:
+            """Update existing records in an Odoo model via XML-RPC.
+
+            WARNING: This modifies data.
+
+            Args:
+                instance: Instance name from instances.json (e.g., 'gno', 'idv')
+                dbname: PostgreSQL database name
+                model: Odoo model name (e.g., 'res.partner')
+                record_ids: List of record IDs to update
+                values: Dictionary of field values to update
+                username: Odoo username (default: 'admin')
+                password: Odoo password (default: 'admin')
+            """
+            return odoo_tools.odoo_write(config, instance, dbname, model, record_ids, values, allow_write=True, username=username, password=password)
+
+    return mcp

--- a/odoo
+++ b/odoo
@@ -8,6 +8,7 @@ Reads instances.json and generates/manages Docker containers for multiple Odoo i
 import argparse
 import json
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -384,6 +385,85 @@ def sync(repo_names, branch, show=False):
             print(f"❌ Error sincronizando {repo_name}: {e}")
         finally:
             os.chdir(BASE_PATH)
+
+
+def mcp_start(config):
+    """Setup and configure bin-odoo-mcp for opencode."""
+    print("\n\033[1;36m=== 🔧 CONFIGURANDO BIN-ODOO-MCP ===\033[0m\n")
+
+    opencode_bin = shutil.which("opencode")
+    if not opencode_bin:
+        fallback = Path.home() / ".opencode" / "bin" / "opencode"
+        if fallback.exists():
+            opencode_bin = str(fallback)
+
+    if not opencode_bin:
+        print("\033[91m❌ opencode no está instalado.\033[0m")
+        print("Instalalo con: curl -fsSL https://opencode.ai/install.sh | bash")
+        sys.exit(1)
+
+    print(f"✓ opencode encontrado en: {opencode_bin}")
+
+    mcp_server_path = Path(BASE_PATH) / "mcp-server"
+    venv_path = mcp_server_path / ".venv"
+
+    if not venv_path.exists():
+        print("\n→ Creando entorno virtual...")
+        result = subprocess.run(
+            [sys.executable, "-m", "venv", str(venv_path)],
+            capture_output=True, text=True
+        )
+        if result.returncode != 0:
+            print(f"\033[91m❌ Error creando venv: {result.stderr}\033[0m")
+            sys.exit(1)
+        print("✓ Entorno virtual creado")
+    else:
+        print("✓ Entorno virtual ya existe")
+
+    venv_pip = venv_path / "bin" / "pip"
+    print("\n→ Instalando dependencias...")
+    result = subprocess.run(
+        [str(venv_pip), "install", "-e", "."],
+        cwd=str(mcp_server_path),
+        capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        print(f"\033[91m❌ Error instalando dependencias: {result.stderr}\033[0m")
+        sys.exit(1)
+    print("✓ Dependencias instaladas")
+
+    opencode_json_path = Path.home() / ".config" / "opencode" / "opencode.json"
+    if not opencode_json_path.exists():
+        print(f"\033[91m❌ No se encontró {opencode_json_path}\033[0m")
+        sys.exit(1)
+
+    with open(opencode_json_path, "r") as f:
+        opencode_config = json.load(f)
+
+    if "mcp" not in opencode_config:
+        opencode_config["mcp"] = {}
+
+    opencode_config["mcp"].pop("odoo-db", None)
+
+    venv_python = venv_path / "bin" / "python"
+    instances_json = str(Path(BASE_PATH) / "instances.json")
+
+    opencode_config["mcp"]["bin-odoo-mcp"] = {
+        "type": "local",
+        "command": [str(venv_python), "-m", "odoo_mcp_server"],
+        "environment": {
+            "INSTANCES_JSON": instances_json,
+            "ALLOW_WRITE": "false"
+        }
+    }
+
+    with open(opencode_json_path, "w") as f:
+        json.dump(opencode_config, f, indent=2)
+
+    print(f"✓ MCP configurado en {opencode_json_path}")
+
+    print("\n\033[92m✅ bin-odoo-mcp configurado correctamente.\033[0m")
+    print("\nReinicia opencode para que los cambios surtan efecto.\n")
 
 
 # ============================================================
@@ -782,6 +862,16 @@ def main():
     sync_p.add_argument("b", nargs="?", default=None, help="Branch (opcional)")
     sync_p.add_argument("--v", action="store_true", default=False, help="Mostrar salida de git")
 
+    # new
+    new_inst_p = subparsers.add_parser("new", help="Crea una nueva instancia (interactivo o por argumentos)")
+    new_inst_p.add_argument("name", nargs="?", default=None, help="Nombre de instancia")
+    new_inst_p.add_argument("repo", nargs="?", default=None, help="URL del repositorio (SSH)")
+    new_inst_p.add_argument("branch", nargs="?", default=None, help="Rama del repositorio")
+    new_inst_p.add_argument("version", nargs="?", default=None, help="Versión de Odoo")
+
+    # mcp-start
+    subparsers.add_parser("mcp-start", help="Configura bin-odoo-mcp para opencode")
+
     args = parser.parse_args()
 
     if not args.action:
@@ -844,7 +934,15 @@ def main():
         if args.b is None:
             args.b = prompt_for_branch(args.r if isinstance(args.r, str) else None)
         sync(args.r, args.b, show=args.v)
-
+    elif args.action == "new":
+        cmd = [sys.executable, os.path.join(BASE_PATH, "scripts", "create_instance.py")]
+        if args.name: cmd.append(args.name)
+        if args.repo: cmd.append(args.repo)
+        if args.branch: cmd.append(args.branch)
+        if args.version: cmd.append(args.version)
+        subprocess.run(cmd)
+    elif args.action == "mcp-start":
+        mcp_start(config)
 
 if __name__ == "__main__":
     main()

--- a/odoo-tui
+++ b/odoo-tui
@@ -13,6 +13,7 @@ Usage:
 """
 
 import asyncio
+import json
 import os
 import shlex
 import shutil
@@ -41,7 +42,11 @@ from textual.widgets import (
 
 BASE_PATH = str(Path(__file__).resolve().parent)
 sys.path.insert(0, os.path.join(BASE_PATH, ".resources"))
-from generators.config_loader import load_config  # noqa: E402
+from generators.config_loader import (  # noqa: E402
+    is_instance_enabled,
+    load_config,
+    load_full_config,
+)
 
 
 # ============================================================
@@ -348,15 +353,22 @@ CATEGORY_BADGE = {
 
 
 class InstanceItem(ListItem):
-    def __init__(self, name: str, version: str, port: int, database: str):
-        super().__init__(Label(f" {name:<14}  {version:<5}  :{port:<5}  db: {database}"))
+    def __init__(self, name: str, version: str, port: int, database: str, enabled: bool = True):
+        row = f" {name:<14}  {version:<5}  :{port:<5}  db: {database}"
+        if not enabled:
+            row = f"[dim]{row}  [off][/dim]"
+        super().__init__(Label(row))
         self.instance_name = name
+        self.instance_enabled = enabled
 
 
 class AllInstancesItem(ListItem):
-    def __init__(self):
-        super().__init__(Label(" Todas las instancias"))
+    def __init__(self, enabled_count: int = 0):
+        label = " Todas las instancias" if enabled_count > 0 else \
+            " [dim]Todas las instancias (ninguna habilitada)[/dim]"
+        super().__init__(Label(label))
         self.instance_name = None
+        self.disabled = enabled_count == 0
 
 
 class ActionItem(ListItem):
@@ -456,13 +468,15 @@ class DockerOdooApp(App):
         Binding("q", "quit", "Salir"),
         Binding("r", "refresh", "Refrescar"),
         Binding("tab", "focus_next", "Siguiente panel"),
+        Binding("space", "toggle_instance", "Toggle enabled"),
     ]
 
     selected_instance: reactive[Optional[str]] = reactive(None)
 
     def __init__(self):
         super().__init__()
-        self.config: dict = {}
+        self.config: dict = {}            # filtered (enabled-only) instances
+        self._raw_config: dict = {}       # unfiltered, used for persistence
         self._last_action: Optional[Action] = None
 
     def compose(self) -> ComposeResult:
@@ -489,22 +503,35 @@ class DockerOdooApp(App):
 
     def refresh_instances(self) -> None:
         try:
-            self.config = load_config(BASE_PATH)
+            self._raw_config = load_full_config(BASE_PATH)
         except SystemExit:
-            self.config = {}
+            self._raw_config = {}
         except Exception as exc:
             self._log(f"[red]Error cargando instances.json:[/red] {exc}")
-            self.config = {}
+            self._raw_config = {}
+
+        # Filtered view used by action dispatch (enabled-only).
+        self.config = {
+            "odoo_configs": self._raw_config.get("odoo_configs", {}),
+            "databases": self._raw_config.get("databases", {}),
+            "instances": {
+                name: inst
+                for name, inst in self._raw_config.get("instances", {}).items()
+                if is_instance_enabled(inst)
+            },
+        }
 
         list_view = self.query_one("#instances_list", ListView)
         list_view.clear()
-        list_view.append(AllInstancesItem())
-        for name, inst in self.config.get("instances", {}).items():
+        enabled_count = len(self.config["instances"])
+        list_view.append(AllInstancesItem(enabled_count=enabled_count))
+        for name, inst in self._raw_config.get("instances", {}).items():
             list_view.append(InstanceItem(
                 name=name,
                 version=inst.get("odoo_version", "?"),
                 port=inst.get("external_port", 0),
                 database=inst.get("database", "?"),
+                enabled=is_instance_enabled(inst),
             ))
         list_view.index = 0
         self.selected_instance = None
@@ -522,6 +549,47 @@ class DockerOdooApp(App):
                 else:
                     list_view.append(NoInstanceActionItem(action))
         list_view.index = 0
+
+    # ---------- toggle persistence ----------
+
+    def action_toggle_instance(self) -> None:
+        """Toggle the ``enabled`` flag of the highlighted instance and persist."""
+        list_view = self.query_one("#instances_list", ListView)
+        item = list_view.highlighted_child
+        if item is None or not isinstance(item, InstanceItem):
+            self._log("[yellow]Space no aplica a 'Todas las instancias'.[/yellow]")
+            return
+        name = item.instance_name
+        if name not in self._raw_config.get("instances", {}):
+            return
+        new_value = not is_instance_enabled(self._raw_config["instances"][name])
+        self._raw_config["instances"][name]["enabled"] = new_value
+        if not self._save_instances_json(self._raw_config):
+            # Revert in-memory change so UI and disk stay in sync.
+            self._raw_config["instances"][name]["enabled"] = not new_value
+            return
+        self._log(
+            f"[green]Instancia[/green] [b]{name}[/b] "
+            f"{'habilitada' if new_value else 'deshabilitada'}."
+        )
+        # Repaint the list, preserving the current selection index.
+        current_index = list_view.index
+        self.refresh_instances()
+        list_view.index = min(current_index, len(list_view.children) - 1)
+
+    def _save_instances_json(self, raw_config: dict) -> bool:
+        """Persist the full (unfiltered) instances.json. Returns True on success."""
+        path = os.path.join(BASE_PATH, "instances.json")
+        try:
+            with open(path, "w") as f:
+                json.dump(raw_config, f, indent=2, ensure_ascii=False)
+                f.write("\n")
+            return True
+        except (OSError, PermissionError) as exc:
+            self._log(
+                f"[red]No se pudo guardar instances.json:[/red] {exc}"
+            )
+            return False
 
     # ---------- event wiring ----------
 
@@ -553,12 +621,29 @@ class DockerOdooApp(App):
 
     def _dispatch(self, action: Action) -> None:
         self._last_action = action
-        # Validate that an instance is available when needed
+        if not self._raw_config.get("instances"):
+            self._log("[red]No hay instancias configuradas en instances.json.[/red]")
+            return
+        # If an instance is needed and the user selected a disabled one, fail.
+        if (
+            ARG_INSTANCE in action.needs
+            and self.selected_instance is not None
+            and self.selected_instance not in self.config["instances"]
+        ):
+            self._log(
+                f"[red]La instancia '{self.selected_instance}' está deshabilitada. "
+                f"Reactivala con Space antes de correr acciones.[/red]"
+            )
+            return
         if ARG_INSTANCE in action.needs and self.selected_instance is None and not action.needs_all_option:
             self._log(f"[red]'{action.label}' requiere seleccionar una instancia.[/red]")
             return
-        if not self.config.get("instances"):
-            self._log("[red]No hay instancias configuradas en instances.json.[/red]")
+        if (
+            self.selected_instance is None
+            and action.needs_all_option
+            and not self.config.get("instances")
+        ):
+            self._log("[red]Todas las instancias están deshabilitadas.[/red]")
             return
 
         # Special-cased no-arg actions
@@ -658,8 +743,17 @@ class DockerOdooApp(App):
 
     async def _execute_all(self, action: Action, args: dict) -> None:
         instances = list(self.config["instances"].keys())
+        disabled = [
+            name for name, inst in self._raw_config.get("instances", {}).items()
+            if not is_instance_enabled(inst)
+        ]
+        if disabled:
+            self._log(
+                f"[dim]Saltando instancia(s) deshabilitada(s): "
+                f"{', '.join(disabled)}[/dim]"
+            )
         self._log(f"[cyan]→ {action.label} para {len(instances)} instancia(s): "
-                  f"{', '.join(instances)}[/cyan]")
+                  f"{', '.join(instances) or '(ninguna habilitada)'}[/cyan]")
         rc_total = 0
         for name in instances:
             self._log(f"[dim]-- {name} --[/dim]")

--- a/odoo-tui
+++ b/odoo-tui
@@ -342,6 +342,149 @@ class ConfirmModal(ModalScreen[bool]):
         self.dismiss(False)
 
 
+class ModulePicker(ModalScreen[Optional[list]]):
+    """fzf-style two-pane module picker.
+
+    Left pane: filtered list of available modules (those found on disk
+    under the instance's resolved addons paths). Modules already in
+    ``selected`` are prefixed with a check mark.
+    Right pane: the modules the user has picked.
+    Bottom: footer with key hints and an Execute button.
+
+    On dismiss returns:
+      * ``None``  -> user cancelled (Esc)
+      * ``[]``    -> user confirmed with an empty selection (interpreted
+                     as ``all`` by the caller; the Execute button label
+                     changes to "Ejecutar (all)" in that case)
+      * ``[m1, m2, ...]`` -> user-confirmed module list
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel_picker", "Cancel"),
+        Binding("l", "clear_selection", "Limpiar"),
+        Binding("e", "execute_picker", "Ejecutar"),
+    ]
+
+    def __init__(
+        self,
+        instance_name: str,
+        available_modules: list,
+        preselected: Optional[list] = None,
+    ):
+        super().__init__()
+        self.instance_name = instance_name
+        self.available_modules = sorted(available_modules)
+        self.preselected = list(preselected or [])
+        self.selected: list[str] = list(self.preselected)
+        self._filter: str = ""
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="modal_box"):
+            yield Label(
+                f"Update módulos — {self.instance_name}", id="modal_title"
+            )
+            yield Label("Filtro:", classes="field_label")
+            yield Input(placeholder="escribí para filtrar", id="filter_input")
+            with Horizontal(id="picker_panes"):
+                with Vertical(id="picker_left"):
+                    yield Label("Disponibles", classes="field_label")
+                    yield ListView(id="available_list")
+                with Vertical(id="picker_right"):
+                    yield Label("A actualizar", classes="field_label")
+                    yield ListView(id="selected_list")
+            with Horizontal(id="modal_buttons"):
+                yield Static(
+                    "[Tab] cambiar   [Enter] +/-   [L] limpiar   "
+                    "[E] ejecutar   [Esc] cancelar",
+                    id="picker_hints",
+                )
+            with Horizontal(id="modal_buttons"):
+                yield Button("Cancelar", id="cancel", variant="error")
+                yield Button("Ejecutar", id="ok", variant="success")
+
+    def on_mount(self) -> None:
+        self._render_available()
+        self._render_selected()
+        self.query_one("#filter_input", Input).focus()
+
+    # ----- rendering -----
+
+    def _render_available(self) -> None:
+        view = self.query_one("#available_list", ListView)
+        view.clear()
+        needle = self._filter.lower()
+        for m in self.available_modules:
+            if needle and needle not in m.lower():
+                continue
+            label = f" ✓ {m}" if m in self.selected else f"   {m}"
+            item = ListItem(Label(label))
+            item.module_name = m  # type: ignore[attr-defined]
+            view.append(item)
+
+    def _render_selected(self) -> None:
+        view = self.query_one("#selected_list", ListView)
+        view.clear()
+        for m in self.selected:
+            item = ListItem(Label(f" ▸ {m}"))
+            item.module_name = m  # type: ignore[attr-defined]
+            view.append(item)
+        self._refresh_execute_label()
+
+    def _refresh_execute_label(self) -> None:
+        btn = self.query_one("#ok", Button)
+        if self.selected:
+            btn.label = f"Ejecutar ({len(self.selected)})"
+        else:
+            btn.label = "Ejecutar (all)"
+
+    # ----- events -----
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if event.input.id != "filter_input":
+            return
+        self._filter = event.value
+        self._render_available()
+
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        item = event.item
+        name = getattr(item, "module_name", None)
+        if name is None:
+            return
+        if event.list_view.id == "available_list":
+            if name in self.selected:
+                self.selected.remove(name)
+            else:
+                self.selected.append(name)
+            self._render_available()
+            self._render_selected()
+        elif event.list_view.id == "selected_list":
+            if name in self.selected:
+                self.selected.remove(name)
+            self._render_available()
+            self._render_selected()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "cancel":
+            self.action_cancel_picker()
+        elif event.button.id == "ok":
+            self.action_execute_picker()
+
+    # ----- actions -----
+
+    def action_cancel_picker(self) -> None:
+        self.dismiss(None)
+
+    def action_clear_selection(self) -> None:
+        self.selected = []
+        self._render_available()
+        self._render_selected()
+
+    def action_execute_picker(self) -> None:
+        # An empty selection means "all" — the caller handles the
+        # semantics; we just hand back an empty list.
+        self.dismiss(list(self.selected))
+
+
 # ============================================================
 # Main screen
 # ============================================================
@@ -466,6 +609,22 @@ class DockerOdooApp(App):
     #modal_buttons Button {
         margin: 0 1;
     }
+    #picker_panes {
+        height: 1fr;
+        margin-top: 1;
+    }
+    #picker_left, #picker_right {
+        width: 1fr;
+        border: round $primary;
+        padding: 0 1;
+    }
+    #picker_left ListView, #picker_right ListView {
+        height: 1fr;
+    }
+    #picker_hints {
+        color: $secondary;
+        padding: 0 1;
+    }
     """
 
     BINDINGS = [
@@ -482,6 +641,7 @@ class DockerOdooApp(App):
         self.config: dict = {}            # filtered (enabled-only) instances
         self._raw_config: dict = {}       # unfiltered, used for persistence
         self._last_action: Optional[Action] = None
+        self.module_cache: dict = {}      # instance -> sorted module names
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
@@ -539,6 +699,37 @@ class DockerOdooApp(App):
             ))
         list_view.index = 0
         self.selected_instance = None
+
+    def _scan_instance_modules(self, inst_name: str, inst_conf: dict) -> list:
+        """Return the sorted list of module names found in the instance's addons paths.
+
+        Results are memoised in ``self.module_cache``. The scan only
+        happens lazily on first request for an instance, never on
+        ``on_mount`` (which would scan every configured instance
+        regardless of whether the user will ever use the picker).
+        """
+        if inst_name in self.module_cache:
+            return self.module_cache[inst_name]
+        try:
+            from generators.config_loader import resolve_instance_config
+        except ImportError:
+            self.module_cache[inst_name] = []
+            return []
+        addons = resolve_instance_config(inst_conf, self.config).get("addons", [])
+        modules: set[str] = set()
+        for path in addons:
+            abs_path = os.path.join(BASE_PATH, path)
+            if not os.path.isdir(abs_path):
+                continue
+            for entry in os.listdir(abs_path):
+                full = os.path.join(abs_path, entry)
+                if (
+                    os.path.isdir(full)
+                    and os.path.isfile(os.path.join(full, "__manifest__.py"))
+                ):
+                    modules.add(entry)
+        self.module_cache[inst_name] = sorted(modules)
+        return self.module_cache[inst_name]
 
     def refresh_actions(self) -> None:
         list_view = self.query_one("#actions_list", ListView)
@@ -655,6 +846,31 @@ class DockerOdooApp(App):
             self.run_worker(self._execute(action, {}), exclusive=False)
             return
 
+        # Special case: the consolidated ``update`` action with an
+        # instance selected can use the fzf-style module picker when
+        # addons paths are available on disk. The text modal remains
+        # the fallback for "all instances" or for instances whose
+        # addons paths did not produce any modules.
+        if action.action_id == "update" and self.selected_instance is not None:
+            inst = self.config["instances"].get(self.selected_instance)
+            if inst is not None:
+                available = self._scan_instance_modules(
+                    self.selected_instance, inst
+                )
+                if available:
+                    self.push_screen(
+                        ModulePicker(
+                            instance_name=self.selected_instance,
+                            available_modules=available,
+                        ),
+                        lambda result: self._on_picker_result(action, result),
+                    )
+                    return
+                self._log(
+                    "[yellow]No se detectaron addons locales; "
+                    "usando input de texto.[/yellow]"
+                )
+
         # Build the fields list and launch the input modal.
         # ARG_INSTANCE is pre-selected from the instance list and is NOT
         # asked again as a modal input.
@@ -746,6 +962,31 @@ class DockerOdooApp(App):
         if action.action_id == "update" and result.get(ARG_MODULES):
             self._warn_unknown_modules(result[ARG_MODULES])
         self.run_worker(self._execute(action, result), exclusive=False)
+
+    def _on_picker_result(
+        self, action: Action, result: Optional[list]
+    ) -> None:
+        """Handle the ModulePicker dismiss for the update action.
+
+        Empty selection means ``all``; a non-empty list is comma-joined
+        for the ``-u`` flag. The DB default is auto-filled from
+        ``overwrite_odoo_config.db_name`` exactly like the text modal
+        flow does, so the picker path and the text modal path converge
+        before reaching :meth:`_execute`.
+        """
+        if result is None:
+            self._log("[yellow]Cancelado.[/yellow]")
+            return
+        modules_str = ",".join(result) if result else "all"
+        if self.selected_instance:
+            inst = self.config["instances"].get(self.selected_instance, {})
+            db_default = inst.get("overwrite_odoo_config", {}).get(
+                "db_name", self.selected_instance
+            )
+        else:
+            db_default = ""
+        args = {ARG_DB: db_default, ARG_MODULES: modules_str}
+        self.run_worker(self._execute(action, args), exclusive=False)
 
     def _warn_unknown_modules(self, modules_str: str) -> None:
         """Log a yellow warning listing modules not found in addons paths."""

--- a/odoo-tui
+++ b/odoo-tui
@@ -67,6 +67,7 @@ ARG_TARGET_PG = "pg_major"  # target postgres major version
 ARG_PATH = "path"           # generic output path
 ARG_TEST_TAGS = "test_tags"
 ARG_INSTALL = "install_modules"
+ARG_LANG = "load_language"  # optional, only used by the update action
 
 
 @dataclass
@@ -134,8 +135,9 @@ ACTIONS: list[Action] = [
 
     # Módulos / DB
     Action("update", "Update módulos", "Módulos / DB",
-           "Actualiza módulos de Odoo (con -d y -m)",
-           needs=[ARG_INSTANCE, ARG_DB, ARG_MODULES]),
+           "Actualiza módulos via scripts/odoo-update (admite --load-language)",
+           needs=[ARG_INSTANCE, ARG_DB, ARG_MODULES],
+           needs_db_first=True),
     Action("pw", "Reset password", "Módulos / DB",
            "Restablece la contraseña de un usuario",
            needs=[ARG_INSTANCE, ARG_DB, ARG_USER, ARG_PASSWORD]),
@@ -169,10 +171,6 @@ ACTIONS: list[Action] = [
            needs=[ARG_INSTANCE, ARG_DB]),
     Action("script:upgrade_manifest", "Bump manifest version", "Scripts",
            "Asistente para incrementar la versión en __manifest__.py"),
-    Action("script:update", "Update (script)", "Scripts",
-           "Actualiza módulos vía scripts/odoo-update",
-           needs=[ARG_INSTANCE, ARG_DB, ARG_MODULES],
-           needs_db_first=True),
 ]
 
 
@@ -220,6 +218,17 @@ def _odoo_cli_args(action: Action, instance: Optional[str], args: dict) -> list:
 
 def _script_args(action: Action, instance: Optional[str], args: dict) -> list:
     """Build argv for invoking scripts/<script>."""
+    # The consolidated ``update`` action lives next to the ``script:*`` ones
+    # but has a bare action_id (no colon). Resolve it explicitly so the rest
+    # of the dispatch can stay generic.
+    if action.action_id == "update":
+        argv = ["scripts/odoo-update", instance, "-d", args["db"]]
+        if args.get("modules"):
+            argv += args["modules"].split(",")
+        if args.get("load_language"):
+            argv.append(f"--load-language={args['load_language']}")
+        return argv
+
     sub = action.action_id.split(":", 1)[1]
     script = {
         "backup": "scripts/odoo_backup",
@@ -229,7 +238,6 @@ def _script_args(action: Action, instance: Optional[str], args: dict) -> list:
         "active_users": "scripts/odoo_active_users",
         "migrate": "scripts/migrate-module",
         "upgrade_manifest": "scripts/odoo-upgrade-manifest",
-        "update": "scripts/odoo-update",
     }[sub]
     argv = [script]
     if sub == "backup":
@@ -252,10 +260,6 @@ def _script_args(action: Action, instance: Optional[str], args: dict) -> list:
         argv += [instance, "-d", args["db"]]
     elif sub == "upgrade_manifest":
         pass
-    elif sub == "update":
-        argv += [instance, "-d", args["db"]]
-        if args.get("modules"):
-            argv += args["modules"].split(",")
     return argv
 
 
@@ -660,6 +664,12 @@ class DockerOdooApp(App):
                 continue
             fields.append(self._arg_to_field(arg))
 
+        # The consolidated ``update`` action exposes an optional
+        # --load-language field on the text modal that is not part of
+        # ``action.needs`` (the fzf-style picker handles its own modal).
+        if action.action_id == "update":
+            fields.append(self._arg_to_field(ARG_LANG))
+
         # If the only thing the action needs was an instance (already
         # selected), skip the modal and run straight away.
         if not fields:
@@ -697,6 +707,8 @@ class DockerOdooApp(App):
                             "placeholder": "/binaural_accountant"},
             ARG_INSTALL: {"key": ARG_INSTALL, "label": "Módulos a instalar (-i)",
                           "placeholder": "account,sale"},
+            ARG_LANG: {"key": ARG_LANG, "label": "Load language (opcional)",
+                       "placeholder": "es_VE"},
         }
         return defaults[arg]
 
@@ -707,8 +719,11 @@ class DockerOdooApp(App):
             defaults[ARG_PASSWORD] = "admin"
         if action.action_id == "update":
             defaults[ARG_MODULES] = "all"
-        if action.action_id == "script:update":
-            defaults[ARG_MODULES] = "all"
+            if self.selected_instance:
+                inst = self.config["instances"].get(self.selected_instance, {})
+                defaults[ARG_DB] = inst.get(
+                    "overwrite_odoo_config", {}
+                ).get("db_name", self.selected_instance)
         if action.action_id == "script:test":
             defaults[ARG_DB] = "testing"
             defaults[ARG_TEST_TAGS] = "/binaural_accountant"
@@ -724,7 +739,50 @@ class DockerOdooApp(App):
         # Convert numeric fields where appropriate
         if ARG_TARGET_PG in result and result[ARG_TARGET_PG].isdigit():
             result[ARG_TARGET_PG] = int(result[ARG_TARGET_PG])
+        # Soft-check that typed modules exist in any of the instance's
+        # addons paths. This is only relevant for the text modal flow of
+        # the ``update`` action; the fzf-style picker already filters
+        # against the scanned module list.
+        if action.action_id == "update" and result.get(ARG_MODULES):
+            self._warn_unknown_modules(result[ARG_MODULES])
         self.run_worker(self._execute(action, result), exclusive=False)
+
+    def _warn_unknown_modules(self, modules_str: str) -> None:
+        """Log a yellow warning listing modules not found in addons paths."""
+        if not modules_str or modules_str.strip().lower() == "all":
+            return
+        if self.selected_instance is None:
+            return
+        inst = self.config["instances"].get(self.selected_instance)
+        if inst is None:
+            return
+        try:
+            from generators.config_loader import resolve_instance_config
+        except ImportError:
+            return
+        addons = resolve_instance_config(inst, self.config).get("addons", [])
+        valid_paths = [
+            a for a in addons
+            if os.path.isdir(os.path.join(BASE_PATH, a))
+        ]
+        missing: list[str] = []
+        for raw in modules_str.split(","):
+            name = raw.strip()
+            if not name:
+                continue
+            found = any(
+                os.path.isfile(
+                    os.path.join(BASE_PATH, a, name, "__manifest__.py")
+                )
+                for a in valid_paths
+            )
+            if not found:
+                missing.append(name)
+        if missing:
+            self._log(
+                f"[yellow]Aviso:[/yellow] módulo(s) no encontrado(s) en "
+                f"addons: {', '.join(missing)}"
+            )
 
     # ---------- execution ----------
 
@@ -765,7 +823,9 @@ class DockerOdooApp(App):
             self._log(f"[red]✗ {action.label} salió con código {rc_total} en al menos una instancia[/red]")
 
     async def _execute_one(self, action: Action, instance: Optional[str], args: dict, *, echo_cmd: bool = True) -> int:
-        if action.action_id.startswith("script:"):
+        # The consolidated ``update`` action routes through scripts/odoo-update
+        # just like the legacy ``script:update`` did.
+        if action.action_id == "update" or action.action_id.startswith("script:"):
             argv = _script_args(action, instance, args)
         else:
             argv = _odoo_cli_args(action, instance, args)

--- a/odoo-tui
+++ b/odoo-tui
@@ -8,8 +8,8 @@ behaviour is untouched: the TUI shells out to the same entrypoints a
 developer would type by hand.
 
 Usage:
-    ./tui.py
-    python3 tui.py
+    ./odoo-tui
+    python3 odoo-tui
 """
 
 import asyncio

--- a/readme.md
+++ b/readme.md
@@ -216,6 +216,26 @@ pip install --user textual
    (DB, módulos, login, archivo ZIP, etc.) aparece un modal para completarlos.
 4. El comando se invoca y el output se stream en el panel inferior.
 
+### Picker fzf para `Update módulos`
+
+La acción `Update módulos` detecta los addons locales de la instancia
+seleccionada (recorriendo los paths declarados en `overwrite_odoo_config`)
+y abre un picker estilo fzf con dos paneles: `Disponibles` (módulos
+encontrados en disco) y `A actualizar` (los que vas acumulando).
+
+- Filtrá tipeando en el campo `Filtro` (match por substring case-insensitive).
+- `Enter` sobre un módulo disponible lo agrega (o lo quita) de la selección.
+- `Tab` cambia el foco entre el campo de filtro y las listas.
+- `L` limpia la selección.
+- `E` ejecuta (o el botón `Ejecutar`).
+- `Esc` cancela.
+
+Si confirmás con la selección vacía, se ejecuta `all` (etiqueta del
+botón cambia a `Ejecutar (all)`). Si la instancia no tiene addons en
+disco, el picker se salta y se usa el modal de texto clásico, que
+además acepta un campo opcional `Load language` para pasarlo como
+`--load-language=es_VE` a `scripts/odoo-update`.
+
 ### Atajos de teclado
 
 | Tecla | Acción |

--- a/readme.md
+++ b/readme.md
@@ -233,10 +233,10 @@ pip install --user textual
 - **Acceso**: `bash`, `logs`, `psql` (suspenden la TUI y devuelven el control
   al terminar el comando interactivo)
 - **Mantenimiento**: `fix-files`, `init`, `validate-instances`, `remove`
-- **Módulos / DB**: `update`, `pw` (reset de password)
+- **Módulos / DB**: `update` (admite `--load-language`), `pw` (reset de password)
 - **Sync**: `sync` (submódulos git de un repo custom)
 - **Scripts**: `backup`, `restore`, `test`, `precommit`, `active-users`,
-  `migrate`, `update-manifest`, `odoo-update`
+  `migrate`, `update-manifest`
 
 `start`/`stop`/`restart`/`logs`/`fix-files`/`init`/`remove` aceptan la
 opción **"Todas las instancias"**; la TUI los itera por vos y evita que

--- a/readme.md
+++ b/readme.md
@@ -192,7 +192,7 @@ Todos los comandos que aceptan `[instance]` operan sobre todas las instancias si
 ./odoo restart
 ```
 
-## TUI interactiva: `./tui.py`
+## TUI interactiva: `./odoo-tui`
 
 Una interfaz de terminal (Textual) que envuelve `./odoo` y los scripts de
 `scripts/`. **No reemplaza el CLI**: `./odoo <comando>` sigue funcionando
@@ -204,7 +204,7 @@ comandos por vos y muestra el output en pantalla.
 pip install --user textual
 
 # Lanzar la TUI
-./tui.py
+./odoo-tui
 ```
 
 ### Flujo

--- a/readme.md
+++ b/readme.md
@@ -83,7 +83,7 @@ Define las conexiones a PostgreSQL. `create_container` (default: `true`) control
 
 ### `instances` — Instancias de Odoo
 
-Cada instancia define su versión de Odoo, puerto externo, base de datos y configuración. Puede sobreescribir valores del `odoo_config` base usando `overwrite_odoo_config`.
+Cada instancia define su versión de Odoo, puerto externo, base de datos y configuración. Puede sobreescribir valores del `odoo_config` base usando `overwrite_odoo_config`. El flag opcional `"enabled"` (default `true`) controla si la instancia aparece en `./odoo build/start/stop/...` y en la TUI; podés togglerlo desde la TUI con `Space` y el cambio se persiste en `instances.json`.
 
 ```json
 {
@@ -106,6 +106,16 @@ Cada instancia define su versión de Odoo, puerto externo, base de datos y confi
       "odoo_config": "17.0_default",
       "overwrite_odoo_config": {
         "addons": ["src/enterprise", "src/custom/client-b"]
+      }
+    },
+    "client-paused": {
+      "enabled": false,
+      "odoo_version": "19.0",
+      "external_port": 8072,
+      "database": "pg16",
+      "odoo_config": "19.0_default",
+      "overwrite_odoo_config": {
+        "addons": ["src/enterprise", "src/custom/client-paused"]
       }
     }
   }

--- a/readme.md
+++ b/readme.md
@@ -224,6 +224,7 @@ pip install --user textual
 | `↑` / `↓` | Navegar dentro de un panel |
 | `Enter` | Seleccionar instancia / ejecutar acción |
 | `r` | Refrescar instancias desde `instances.json` |
+| `Space` | Toggle `enabled` de la instancia seleccionada (persiste en `instances.json`) |
 | `q` / `Esc` | Salir / cancelar modal |
 
 ### Acciones soportadas

--- a/scripts/create_instance.py
+++ b/scripts/create_instance.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+import json
+import sys
+import os
+import subprocess
+from pathlib import Path
+
+BASE_PATH = Path(__file__).resolve().parent.parent
+INSTANCES_FILE = BASE_PATH / "instances.json"
+CUSTOM_DIR = BASE_PATH / "src" / "custom"
+
+
+def get_used_ports(data):
+    return [
+        inst["external_port"]
+        for inst in data.get("instances", {}).values()
+        if "external_port" in inst
+    ]
+
+
+def get_suggested_port(used_ports):
+    return max(used_ports) + 1 if used_ports else 8069
+
+
+def interactive_menu(prompt_text, options_list):
+    """
+    Muestra un menú interactivo. options_list es una lista de tuplas (numero, texto, valor_retorno).
+    """
+
+    def fallback_prompt():
+        print(f"\n{prompt_text}")
+        for num, text, _ in options_list:
+            print(f"  {num}) {text}")
+        while True:
+            choice = input("Opción: ").strip()
+            for num, text, val in options_list:
+                if str(num) == choice:
+                    return val
+            print("❌ Opción inválida.")
+
+    if not sys.stdin.isatty():
+        return fallback_prompt()
+
+    try:
+        import tty
+        import termios
+    except ImportError:
+        return fallback_prompt()
+
+    def getch():
+        fd = sys.stdin.fileno()
+        try:
+            old_settings = termios.tcgetattr(fd)
+        except Exception:
+            return sys.stdin.read(1)
+        try:
+            tty.setraw(fd)
+            ch = sys.stdin.read(1)
+            if ch == "\x1b":
+                ch += sys.stdin.read(2)
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+        return ch
+
+    current_idx = 0
+    input_buffer = ""
+    lines_to_clear = len(options_list)
+
+    print(f"\n{prompt_text} (Usa las flechas, números y Enter para confirmar):")
+
+    def render_menu():
+        sys.stdout.write("\r")
+        for i, (num, text, _) in enumerate(options_list):
+            prefix = "❯ " if i == current_idx else "  "
+            if i == current_idx:
+                sys.stdout.write(f"\033[92m{prefix}{num}. {text}\033[0m\033[K\n")
+            else:
+                sys.stdout.write(f"{prefix}{num}. {text}\033[K\n")
+        sys.stdout.write(f"Opción [ {input_buffer} ]: \033[K")
+        sys.stdout.flush()
+
+    sys.stdout.write("\033[?25l")
+    try:
+        render_menu()
+        while True:
+            ch = getch()
+            if ch == "\x03":  # Ctrl+C
+                raise KeyboardInterrupt
+            elif ch in ("\r", "\n"):
+                sys.stdout.write("\n")
+                break
+            elif ch == "\x1b[A":  # Arriba
+                current_idx = (current_idx - 1) % len(options_list)
+                input_buffer = ""
+            elif ch == "\x1b[B":  #s Abajo
+                current_idx = (current_idx + 1) % len(options_list)
+                input_buffer = ""
+            elif ch in ("\x7f", "\b"):  # Backspace
+                input_buffer = input_buffer[:-1]
+            elif len(ch) == 1 and ch.isdigit():
+                input_buffer += ch
+                try:
+                    num_val = int(input_buffer)
+                    for i, (num, text, _) in enumerate(options_list):
+                        if num == num_val:
+                            current_idx = i
+                            break
+                except ValueError:
+                    pass
+
+            sys.stdout.write(f"\033[{lines_to_clear}F")
+            render_menu()
+
+    except Exception:
+        sys.stdout.write("\033[?25h\nOperación cancelada.\n")
+        sys.exit(0)
+    finally:
+        sys.stdout.write("\033[?25h")
+
+    return options_list[current_idx][2]
+
+
+def is_ssh_url(url):
+    return url.startswith("git@") or url.startswith("ssh://")
+
+
+def create_instance(name, repo_url, branch, odoo_version):
+    if not is_ssh_url(repo_url):
+        print(
+            "❌ Error: La URL del repositorio debe ser SSH (debe empezar con 'git@' o 'ssh://')."
+        )
+        print("💡 Ejemplo válido: git@github.com:usuario/repo.git")
+        print(
+            "💡 Las URLs que empiezan con 'http://' o 'https://' no están permitidas."
+        )
+        sys.exit(1)
+
+    if not INSTANCES_FILE.exists():
+        print("Error: instances.json no encontrado.")
+        sys.exit(1)
+
+    with open(INSTANCES_FILE, "r") as f:
+        data = json.load(f)
+
+    if name in data.get("instances", {}):
+        print(f"Error: La instancia '{name}' ya existe en instances.json.")
+        sys.exit(1)
+
+    repo_path = CUSTOM_DIR / name
+    if repo_path.exists():
+        print(f"Advertencia: El directorio {repo_path} ya existe. Saltando clone.")
+    else:
+        print(f"Clonando repositorio {repo_url} (rama: {branch}) en {repo_path}...")
+        try:
+            subprocess.run(
+                ["git", "clone", "-b", branch, repo_url, str(repo_path)], check=True
+            )
+
+            print(f"Inicializando submódulos para {name}...")
+            subprocess.run(
+                ["git", "submodule", "update", "--init", "--recursive"],
+                cwd=str(repo_path),
+                check=True,
+            )
+        except subprocess.CalledProcessError:
+            print(
+                "❌ Error al clonar el repositorio o sus submódulos. Verifica la URL, permisos de acceso o problemas de conexión."
+            )
+            print("Limpiando directorio incompleto...")
+            import shutil
+
+            if repo_path.exists():
+                shutil.rmtree(repo_path)
+            sys.exit(1)
+
+    used_ports = get_used_ports(data)
+    suggested_port = get_suggested_port(used_ports)
+
+    while True:
+        try:
+            port_input = input(
+                f"\nIngresa el puerto externo para la instancia [Sugerido: {suggested_port}]: "
+            ).strip()
+            if not port_input:
+                next_port = suggested_port
+            else:
+                next_port = int(port_input)
+
+            if next_port in used_ports:
+                print(
+                    f"❌ Error: El puerto {next_port} ya está ocupado por otra instancia."
+                )
+                print(f"💡 Sugerencia: Puedes usar el puerto {suggested_port}")
+                continue
+            break
+        except ValueError:
+            print("❌ Error: Por favor ingresa un número de puerto válido.")
+
+    requested_config = f"{odoo_version}_default"
+    available_configs = data.get("odoo_configs", {}).keys()
+
+    if requested_config in available_configs:
+        odoo_config = requested_config
+    elif "default" in available_configs:
+        odoo_config = "default"
+    else:
+        print(
+            f"❌ Error: No existe la configuración '{requested_config}' ni 'default' en la sección odoo_configs del JSON."
+        )
+        sys.exit(1)
+
+    addons_list = []
+
+    major_version = odoo_version.split(".")[0]
+    enterprise_folder = f"src/enterprise-{major_version}"
+    if (BASE_PATH / enterprise_folder).exists():
+        addons_list.append(enterprise_folder)
+    else:
+        addons_list.append("src/enterprise")
+
+    addons_list.append(f"src/custom/{name}")
+
+    gitmodules_path = repo_path / ".gitmodules"
+    if gitmodules_path.exists():
+        print(
+            f"🔍 Archivo .gitmodules detectado. Extrayendo rutas de submódulos para el JSON..."
+        )
+        import configparser
+
+        config_parser = configparser.ConfigParser()
+        try:
+            config_parser.read(gitmodules_path)
+            for section in config_parser.sections():
+                if "path" in config_parser[section]:
+                    sub_path = config_parser[section]["path"]
+                    addons_list.append(f"src/custom/{name}/{sub_path}")
+        except Exception as e:
+            print(
+                f"⚠️ Advertencia: No se pudo parsear el .gitmodules automáticamente: {e}"
+            )
+
+    if "instances" not in data:
+        data["instances"] = {}
+
+    data["instances"][name] = {
+        "odoo_version": odoo_version,
+        "external_port": next_port,
+        "database": "pg16",
+        "odoo_config": odoo_config,
+        "overwrite_odoo_config": {"addons": addons_list},
+    }
+
+    with open(INSTANCES_FILE, "w") as f:
+        json.dump(data, f, indent=2)
+
+    print(
+        f"\n✅ Instancia '{name}' creada exitosamente en instances.json con el puerto {next_port}!"
+    )
+
+    print("\n🚀 Aplicando cambios automáticamente (stop -> build -> start)...")
+    try:
+        print("\n>> Ejecutando: ./odoo stop")
+        subprocess.run(["./odoo", "stop", "all"], cwd=BASE_PATH, check=True)
+
+        print("\n>> Ejecutando: ./odoo build")
+        subprocess.run(["./odoo", "build"], cwd=BASE_PATH, check=True)
+
+        print("\n>> Ejecutando: ./odoo start")
+        subprocess.run(["./odoo", "start", "all"], cwd=BASE_PATH, check=True)
+
+        print(
+            f"\n🎉 ¡Instancia {name} lista y ejecutándose en http://localhost:{next_port}!\n"
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"\n❌ Error al ejecutar los comandos de Odoo: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    print("\n=== Creador de Instancias Odoo ===")
+    try:
+        name = sys.argv[1] if len(sys.argv) > 1 else ""
+        while not name:
+            name = input("📦 Ingresa el nombre de la instancia (ej. micliente): ").strip()
+
+        repo_url = sys.argv[2] if len(sys.argv) > 2 else ""
+        while not repo_url or not is_ssh_url(repo_url):
+            if repo_url and not is_ssh_url(repo_url):
+                print("❌ Error: La URL debe ser SSH (git@... o ssh://...)")
+            repo_url = input("🔗 Ingresa la URL SSH del repositorio: ").strip()
+
+        branch = sys.argv[3] if len(sys.argv) > 3 else ""
+        while not branch:
+            branch_options = [
+                (1, "release", "release"),
+                (2, "staging", "staging"),
+                (3, "otra", "otra"),
+            ]
+            branch_choice = interactive_menu(
+                "🌿 Selecciona la rama del repositorio", branch_options
+            )
+
+            if branch_choice == "otra":
+                while not branch:
+                    branch = input("🌿 Ingresa el nombre de la rama: ").strip()
+            else:
+                branch = branch_choice
+
+        odoo_version = sys.argv[4] if len(sys.argv) > 4 else ""
+        while not odoo_version:
+            version_options = [(1, "17.0", "17.0"), (2, "19.0", "19.0")]
+            odoo_version = interactive_menu(
+                "⚙️  Selecciona la versión de Odoo", version_options
+            )
+
+        create_instance(name, repo_url, branch, odoo_version)
+    except (KeyboardInterrupt, EOFError):
+        print("\nOperación cancelada.")
+        sys.exit(130)


### PR DESCRIPTION
## Resumen (TL;DR)

[FEAT] tui: enabled toggle persistente, picker fzf para módulos, update flow consolidado (DB auto-fill, validación, `--load-language`). 5 commits, additive sobre `./odoo` y `scripts/*` (sin cambios). Rename `tui.py` → `odoo-tui` para alinear con la familia `./odoo*`.

## Contexto / Motivación

Tres problemas en la TUI actual:

1. **Flag `enabled` invisible para la UI**: `config_loader.load_config` filtra las instancias con `enabled: false` antes de que la TUI las viera. Imposible toggear el flag desde la UI; había que editar `instances.json` a mano.
2. **Update con friction**: había que tipear módulos a mano sin validación contra el árbol `addons`. Dos acciones redundantes (`update` y `script:update`) con defaults hardcoded a Binaural y diferencias sutiles (workers, http-port, `--load-language`).
3. **Naming inconsistente**: `tui.py` rompía la familia `./odoo*` que ya tiene `./odoo`, `scripts/odoo_backup`, `scripts/odoo-test`, etc.

## Descripción técnica

- **`load_full_config()` en `config_loader.py`**: nueva función que devuelve el JSON sin filtrar; `load_config` queda intacto (lo siguen usando `./odoo` y los generators — verificado con `git diff -- odoo` y `git diff -- scripts/`). Helper `is_instance_enabled()` con default `True`.
- **Toggle `enabled` persistente**: la TUI usa `load_full_config`, muestra las deshabilitadas con rendering dim + badge `[off]`. Tecla `Space` toggle + `json.dump(indent=2, ensure_ascii=False)`. Si la escritura falla, revierte in-memory y loguea el error. Cuando todas las instancias están deshabilitadas, el item "Todas las instancias" se atenúa y se niega el dispatch.
- **Update flow consolidado**: una sola acción `Action("update", ...)` que rutea a `scripts/odoo-update` con `ARG_LANG` opcional. `ARG_DB` auto-rellenado desde `overwrite_odoo_config.db_name` (fallback al instance name). Validación de módulos contra `addons` paths (warning, no bloquea). `Action("script:update")` removida.
- **`ModulePicker` modal fzf-style**: `Input` de filtro arriba (live substring match, case-insensitive), `ListView` de disponibles con `✓` para los ya seleccionados, `ListView` de "A actualizar" a la derecha. Enter mueve/saca. Esc cancela. Vacío = `all`. Cache de módulos por instancia (lazy, escanea filesystem). Fallback automático al `InputModal` de texto si los addons dirs están vacíos o no existen.
- **Documentación**: rename, atajo `Space`, sección del picker, ejemplo `enabled: false` en `readme.md`. `instances.example.json` agrega `client-paused`.

**Archivos modificados:**
- `tui.py` → `odoo-tui` (rename con `git mv`, historial preservado)
- `.resources/generators/config_loader.py` (+32 líneas)
- `instances.example.json` (+13 líneas)
- `readme.md` (+41 / -1 líneas)

**Sin cambios en:**
- `./odoo` — verificado `git diff master-multi_bin-daldana..HEAD -- odoo` vacío
- `scripts/*` — verificado `git diff master-multi_bin-daldana..HEAD -- scripts/` vacío

## ¿Cómo se probó?

- [x] `python3 -c "import ast; ast.parse(open('odoo-tui').read())"` OK en los 5 commits
- [x] `grep -rn "tui\.py"` → 0 matches
- [x] Tests de comportamiento vía importlib:
  - `load_full_config` vs `load_config` (19 instancias con 18 deshabilitadas vs 1 habilitada)
  - `is_instance_enabled` para `{}`, `{"enabled": False}`, `{"enabled": True}`
  - `_scan_instance_modules` con fixture (3 dirs, 2 con manifest, 1 sin; verifica sort, cache, fallback a addons dir inexistente, fallback a `addons` key ausente)
  - `_script_args("update")`: baseline, con `--load-language=es_VE`, con `modules="sale,purchase"`
  - `_save_instances_json`: revert in-memory en `PermissionError`
- [x] Action table: 1 `update`, 0 `script:update`, 22 action_ids únicos
- [x] Calidad: sin `print()` debug, sin `TODO/FIXME/XXX`, sin `import *`, sin `except:` bare, type hints en funciones nuevas
- [x] `./odoo --help` y `scripts/odoo-test --help` sin cambios
- [x] `git log --follow odoo-tui` muestra el commit original `0cb2a22` (rename preserva historial)
- [ ] **Playtest manual del picker en TTY** — no se pudo en este entorno headless. Recomendado antes de aprobar el review.

## Breaking changes

- `./tui.py` ya no existe; usar `./odoo-tui` (alias documentado en readme).
- `Action("script:update")` removida; unificada en `Action("update")` con soporte opcional para `--load-language`.

## Follow-ups sugeridos (no incluidos en este PR)

- Wirear `ConfirmModal` a la acción `remove` (clase ya existe como dead code).
- Decidir uso o remoción del atributo `needs_db_first` (declarado pero nunca leído).
- Test unitario de `ModulePicker.on_list_view_selected` para ambos paneles.
- Fix pre-existente en `instances.example.json`: `client-b` referencia `external_pg16` que no está definida en `databases`.
- Considerar CSS externo (`CSS_PATH = "odoo-tui.tcss"`) + `textual run --dev` en un PR futuro (mejora de DX sin cambio funcional).

## References

- Ticket: none
- Tarea: none
