### PR TITLE
[DOC] actualizar README módulos personalizados solaris-core

### DIFF
--- a/src/custom/solaris-core/README.md
+++ b/src/custom/solaris-core/README.md
@@ -1,0 +1,59 @@
+# Solaris-Core — Módulos Personalizados
+
+[//]: # (addons)
+
+## Módulos Personalizados
+
+| Módulo | Descripción |
+| --- | --- |
+| [l10n_binaural](odoo-venezuela/l10n_binaural) | Plan de cuentas de servicio con cuentas contables y diarios para empresas de servicios |
+| [l10n_binaural_hide_studio_menu](odoo-venezuela/l10n_binaural_hide_studio_menu) | Bloquear botón de Odoo Studio según grupo de acceso |
+| [l10n_ve_auditlog](odoo-venezuela/l10n_ve_auditlog) | Módulo de Auditoría de la localización de Venezuela |
+| [l10n_ve_base](odoo-venezuela/l10n_ve_base) | Módulo Base de la localización de Venezuela |
+| [l10n_ve_binaural](odoo-venezuela/l10n_ve_binaural) | Plan de cuentas y datos base para Venezuela |
+| [l10n_ve_binaural_purchase_discount](odoo-venezuela/l10n_ve_binaural_purchase_discount) | Descuento global en órdenes de compra |
+| [l10n_ve_contact](odoo-venezuela/l10n_ve_contact) | Módulo para información de contactos de Venezuela |
+| [l10n_ve_currency_rate_live](odoo-venezuela/l10n_ve_currency_rate_live) | Sincronización automática del tipo de cambio oficial BCV |
+| [l10n_ve_dispatch_guide_digital](odoo-venezuela/l10n_ve_dispatch_guide_digital) | Guía de Despacho Digital |
+| [l10n_ve_filter_partner](odoo-venezuela/l10n_ve_filter_partner) | Mixin para filtrar contactos de clientes y proveedores |
+| [l10n_ve_fiscal_lock_days](odoo-venezuela/l10n_ve_fiscal_lock_days) | Restricción de creación de facturas por días fiscales |
+| [l10n_ve_igtf](odoo-venezuela/l10n_ve_igtf) | Impuesto a las Grandes Transacciones Financieras (IGTF) |
+| [l10n_ve_invoice](odoo-venezuela/l10n_ve_invoice) | Módulo de Facturación Venezuela |
+| [l10n_ve_invoice_digital](odoo-venezuela/l10n_ve_invoice_digital) | Facturación Digital |
+| [l10n_ve_invoice_loyalty](odoo-venezuela/l10n_ve_invoice_loyalty) | Módulo de lealtad para facturación Venezolana |
+| [l10n_ve_iot_mf](odoo-venezuela/l10n_ve_iot_mf) | Integración IoT con Máquina Fiscal HKA |
+| [l10n_ve_location](odoo-venezuela/l10n_ve_location) | Modelos de ciudades, municipios y parroquias de Venezuela |
+| [l10n_ve_payment_extension](odoo-venezuela/l10n_ve_payment_extension) | Módulo de Retenciones (ISLR, municipales, IVA) |
+| [l10n_ve_pos](odoo-venezuela/l10n_ve_pos) | Punto de Venta (POS) adaptado a Venezuela |
+| [l10n_ve_pos_igtf](odoo-venezuela/l10n_ve_pos_igtf) | Cálculo de IGTF en operaciones de POS |
+| [l10n_ve_pos_mf](odoo-venezuela/l10n_ve_pos_mf) | Integración POS con Máquina Fiscal |
+| [l10n_ve_purchase](odoo-venezuela/l10n_ve_purchase) | Gestión de compras adaptada a Venezuela |
+| [l10n_ve_rate](odoo-venezuela/l10n_ve_rate) | Configuración del tipo de cambio de Venezuela |
+| [l10n_ve_ref_bank](odoo-venezuela/l10n_ve_ref_bank) | Referencias Bancarias |
+| [l10n_ve_sale](odoo-venezuela/l10n_ve_sale) | Módulo de Ventas Venezuela |
+| [l10n_ve_stock](odoo-venezuela/l10n_ve_stock) | Inventario para la localización en Venezuela |
+| [l10n_ve_stock_account](odoo-venezuela/l10n_ve_stock_account) | Inventario/Contabilidad para la localización en Venezuela |
+| [l10n_ve_stock_purchase](odoo-venezuela/l10n_ve_stock_purchase) | Gestión de inventario/compras en Venezuela |
+| [l10n_ve_stock_reports](odoo-venezuela/l10n_ve_stock_reports) | Libro de Inventario Venezuela |
+| [l10n_ve_studio](odoo-venezuela/l10n_ve_studio) | Limitación de Odoo Studio para la localización en Venezuela |
+| [l10n_ve_tax](odoo-venezuela/l10n_ve_tax) | Impuestos para la localización en Venezuela |
+| [l10n_ve_tax_payer](odoo-venezuela/l10n_ve_tax_payer) | Configuración de contribuyentes de Venezuela |
+| [l10n_ve_accountant](odoo-venezuela/l10n_ve_accountant) | Módulo de Contabilidad Venezuela |
+| [l10n_ve_account_fiscalyear_closing](odoo-venezuela/l10n_ve_account_fiscalyear_closing) | Procesos de cierre de fin de año fiscal en Venezuela |
+
+[//]: # (end addons)
+
+[//]: # (author)
+
+## Autor
+
+### Binaural C.A
+
+Somos la fábrica de software que te impulsará profesionalmente.
+Especialistas en implementación de Odoo.
+
+**Sitio web:** https://binauraldev.com/
+**Correo:** contacto@binauraldev.com
+**GitHub:** https://github.com/binaural-dev
+
+[//]: # (end author)


### PR DESCRIPTION
## Cambios

- Actualiza README.md del repositorio solaris-core
- Remueve todas las referencias a integra-addons y third-party-addons
- Incluye SOLO módulos personalizados propios del cliente en odoo-venezuela

## Módulos documentados (35)

- Módulos de localización venezolana (l10n_ve_*)
- Módulos Binaural (l10n_binaural, l10n_binaural_hide_studio_menu)
- Módulos de contabilidad (l10n_ve_accountant, l10n_ve_account_fiscalyear_closing)

**Excluidos:** integra-addons, third-party-addons, account_fiscal_year_closing (OCA), od_journal_sequence (tercero)