### PR TITLE
[FIX]  compose_generator, db.dockerfile

### DIFF
--- a/.resources/db.Dockerfile
+++ b/.resources/db.Dockerfile
@@ -6,4 +6,3 @@ USER root
 RUN apt-get update && apt-get install -y postgresql-${POSTGRES_IMG_VERSION}-pgvector && rm -rf /var/lib/apt/lists/*
 COPY .resources/db_install_extensions.sh /docker-entrypoint-initdb.d/install_extensions.sh
 RUN chmod +x /docker-entrypoint-initdb.d/install_extensions.sh
-USER postgres

--- a/.resources/generators/compose_generator.py
+++ b/.resources/generators/compose_generator.py
@@ -232,7 +232,6 @@ def _nginx_service(config):
     lines = [
         "  nginx:",
         "    restart: always",
-        "    container_name: odoo-nginx",
         "    image: nginx:latest",
         # "    depends_on:",
     ]


### PR DESCRIPTION
Ajuste para evitar falllos por permisos de usuarios en el contenedor de postgres al utilizar el usuario postgres

Correccion para evitar conflictos al utilizar dos docker-odoo multi en un mismo directorio por nginx con nombres similares. Ahora se infiere nativamente por docker segun su carpeta contenedora.