### PR TITLE
[FIX] Aislar bases de datos en la red interna de Docker

### DIFF
--- a/.resources/generators/compose_generator.py
+++ b/.resources/generators/compose_generator.py
@@ -9,6 +9,7 @@ from .config_loader import (
     resolve_instance_config,
     resolve_db_config,
     get_db_host,
+    get_db_internal_port,
     get_managed_databases,
     get_odoo_minor,
 )
@@ -81,6 +82,7 @@ def _db_service(db_name, db_conf):
     user = db_conf["user"]
     password = db_conf["password"]
     pg_config = db_conf.get("config")
+    expose_host_port = db_conf.get("expose_host_port", False)
     container_name = f"db-{db_name}"
 
     lines = [
@@ -101,8 +103,18 @@ def _db_service(db_name, db_conf):
         "      args:",
         f"        POSTGRES_IMG_VERSION: {pg_version}",
         f"    image: local_odoo_db_{db_name}:{pg_version}",
-        "    ports:",
-        f'      - "{port}:5432"',
+    ]
+
+    # Host port publishing is opt-in: by default Postgres is only reachable
+    # from sibling containers over the internal Docker network (db-<name>:5432).
+    # Set "expose_host_port": true on the database config to publish it.
+    if expose_host_port:
+        lines += [
+            "    ports:",
+            f'      - "{port}:5432"',
+        ]
+
+    lines += [
         f"    networks:",
         f"      - {NETWORK_NAME}",
         "    volumes:",
@@ -123,7 +135,10 @@ def _odoo_service(inst_name, inst_conf, odoo_conf, db_name, db_conf, dockerfile)
     odoo_minor = get_odoo_minor(odoo_version)
     container_name = f"odoo-{inst_name}"
     db_host = get_db_host(db_name, db_conf)
-    db_port = db_conf["port"]
+    # NOTE: db_conf["port"] is the HOST-side port (only published when
+    # expose_host_port is set) — not reachable from sibling containers.
+    # Odoo always talks to Postgres over the internal Docker network.
+    db_port = get_db_internal_port(db_conf)
     db_user = db_conf["user"]
     db_password = db_conf["password"]
 
@@ -269,8 +284,6 @@ def _pgadmin_service(pgadmin_conf):
         "    environment:",
         f"      PGADMIN_DEFAULT_EMAIL: {email}",
         f"      PGADMIN_DEFAULT_PASSWORD: {password}",
-        "    extra_hosts:",
-        '      - "db:host-gateway"',
         "    ports:",
         f'      - "{port}:80"',
         f"    networks:",

--- a/.resources/generators/config_loader.py
+++ b/.resources/generators/config_loader.py
@@ -120,13 +120,27 @@ def resolve_db_config(inst_conf, config):
 def get_db_host(db_name, db_conf):
     """
     Get the DB host for a given database config.
-    For managed DBs, returns the container name. For external DBs, returns the host.
+    For managed DBs, returns the container name (reachable via Docker's
+    internal DNS on the shared network — no host port forwarding involved).
+    For external DBs, returns the host.
     """
     create_container = db_conf.get("create_container", True)
     if create_container:
-        # return f"db-{db_name}"
-        return "host.docker.internal"
+        return f"db-{db_name}"
     return db_conf["host"]
+
+
+def get_db_internal_port(db_conf):
+    """Return the port Postgres listens on *inside* its container.
+
+    ``db_conf['port']`` is the **host-side** port used only when
+    ``expose_host_port`` is enabled (``ports: "<port>:5432"`` in compose).
+    Containers always talk to Postgres over the internal Docker network,
+    where the postgres image listens on 5432 regardless of the host
+    mapping. Use this instead of ``db_conf['port']`` for anything that
+    connects to Postgres from another container (Odoo, docker exec, etc).
+    """
+    return int(db_conf.get("internal_port", 5432))
 
 
 def get_unique_odoo_versions(config):

--- a/instances.example
+++ b/instances.example
@@ -56,7 +56,8 @@
   "databases": {
     "local_pg16": {
       "postgres_version": 16,                  # Version de PostgreSQL a usar (16, 15, 14, etc.)
-      "port": 5432,                            # Puerto expuesto en el host para conectarse a PostgreSQL
+      "port": 5432,                            # Puerto en el host, solo se publica si expose_host_port=true
+      "expose_host_port": false,               # true: publica "port" en el host (docker-compose ports). Por defecto la DB solo es alcanzable dentro de la red interna de Docker (db-<nombre>:5432)
       "user": "odoo",                          # Usuario de PostgreSQL (tambien usado por Odoo)
       "password": "odoo",                      # Password de PostgreSQL (tambien usado por Odoo)
       "config": "postgresql.conf",             # Archivo de configuracion de PostgreSQL en .resources/dbconfigs/
@@ -64,7 +65,7 @@
     },
     "external_pg16": {
       "postgres_version": 16,                  # Version de PostgreSQL (para referencia)
-      "port": 5432,                            # Puerto expuesto en el host
+      "port": 5432,                            # Puerto de la base de datos externa
       "user": "odoo",                          # Usuario de PostgreSQL
       "password": "odoo",                      # Password de PostgreSQL
       "create_container": false,               # false: No crea contenedor, conecta a base de datos externa

--- a/instances.example.json
+++ b/instances.example.json
@@ -24,6 +24,7 @@
     "pg16": {
       "postgres_version": 16,
       "port": 5432,
+      "expose_host_port": false,
       "user": "odoo",
       "password": "odoo",
       "config": "postgresql.conf"

--- a/odoo
+++ b/odoo
@@ -21,6 +21,7 @@ from generators.config_loader import (
     resolve_instance_config,
     resolve_db_config,
     get_db_host,
+    get_db_internal_port,
     get_unique_odoo_versions,
     get_managed_databases,
 )
@@ -256,7 +257,7 @@ def psql_connect(config, instance, dbname):
     db_host = get_db_host(inst_conf["database"], db_conf)
     db_user = db_conf["user"]
     db_password = db_conf["password"]
-    db_port = db_conf["port"]
+    db_port = get_db_internal_port(db_conf)
     container = f"odoo-{instance}"
 
     print(f"\n\033[1;34m=== 🐘 CONECTANDO PSQL A: {instance.upper()} (DB: {dbname}) ===\033[0m\n")
@@ -306,7 +307,7 @@ def reset_password(config, instance, dbname, login, password):
     db_host = get_db_host(inst_conf["database"], db_conf)
     db_user = db_conf["user"]
     db_password = db_conf["password"]
-    db_port = db_conf["port"]
+    db_port = get_db_internal_port(db_conf)
     container = f"odoo-{instance}"
 
     pw = f"'{password}'"
@@ -399,7 +400,7 @@ def get_databases(config, instance):
         db_host = get_db_host(inst_conf["database"], db_conf)
         db_user = db_conf["user"]
         db_password = db_conf["password"]
-        db_port = db_conf["port"]
+        db_port = get_db_internal_port(db_conf)
         container = f"odoo-{instance}"
 
         # Try to get databases from postgres
@@ -424,7 +425,7 @@ def get_users(config, instance, dbname):
         db_host = get_db_host(inst_conf["database"], db_conf)
         db_user = db_conf["user"]
         db_password = db_conf["password"]
-        db_port = db_conf["port"]
+        db_port = get_db_internal_port(db_conf)
         container = f"odoo-{instance}"
 
         cmd = (

--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,7 @@ Define las conexiones a PostgreSQL. `create_container` (default: `true`) control
     "pg16": {
       "postgres_version": 16,
       "port": 5432,
+      "expose_host_port": false,
       "user": "odoo",
       "password": "odoo",
       "config": "postgresql.conf"
@@ -80,6 +81,10 @@ Define las conexiones a PostgreSQL. `create_container` (default: `true`) control
   }
 }
 ```
+
+Las bases de datos gestionadas (`create_container: true`) **no publican su puerto al host por defecto**: los contenedores Odoo se conectan directamente a `db-<nombre>:5432` a través de la red interna de Docker (`odoo-multi`), sin pasar por el host. Esto evita que un Postgres corriendo localmente en la máquina (Homebrew, Postgres.app, etc.) sobre el mismo puerto termine interceptando las conexiones.
+
+Si necesitas conectarte a la base de datos desde el host (por ejemplo con un cliente de escritorio), agrega `"expose_host_port": true` para que se publique `port` en `docker-compose.generated.yml`. Para uso normal (`./odoo psql`, `./odoo bash`, backups, restores, pgAdmin) no hace falta: todos corren dentro de los contenedores y usan la red interna.
 
 ### `instances` — Instancias de Odoo
 

--- a/scripts/odoo-pw
+++ b/scripts/odoo-pw
@@ -8,7 +8,12 @@ from pathlib import Path
 
 BASE_PATH = str(Path(__file__).resolve().parent.parent)
 sys.path.insert(0, os.path.join(BASE_PATH, ".resources"))
-from generators.config_loader import load_config, resolve_db_config, get_db_host
+from generators.config_loader import (
+    load_config,
+    resolve_db_config,
+    get_db_host,
+    get_db_internal_port,
+)
 
 
 @click.command()
@@ -27,7 +32,7 @@ def run_command(instance, d, l, password):
     db_host = get_db_host(inst_conf["database"], db_conf)
     db_user = db_conf["user"]
     db_password = db_conf["password"]
-    db_port = db_conf["port"]
+    db_port = get_db_internal_port(db_conf)
     container = f"odoo-{instance}"
 
     pw = f"'{password}'"

--- a/scripts/odoo_active_users
+++ b/scripts/odoo_active_users
@@ -16,36 +16,29 @@ Este script considera que un usuario ya no esta usando el ambiente cuando su
 ultima marca de presencia queda fuera de la ventana definida por --minutes.
 Solo cuenta usuarios activos y, salvo que se indique lo contrario, excluye
 usuarios portal/share.
+
+La consulta corre dentro del contenedor de la instancia (`docker exec`), ya
+que las bases de datos ya no publican su puerto al host por defecto: el
+contenedor Odoo ya trae las variables PGHOST/PGPORT/PGUSER/PGPASSWORD
+correctas para hablar con su base de datos por la red interna de Docker.
 """
 
 import argparse
 import os
+import subprocess
 import sys
 from pathlib import Path
-from typing import Optional
-
-import psycopg2
 
 BASE_PATH = str(Path(__file__).resolve().parent.parent)
 sys.path.insert(0, os.path.join(BASE_PATH, ".resources"))
-from generators.config_loader import (
-    load_config,
-    resolve_db_config,
-    get_db_host,
-)
+from generators.config_loader import load_config
 
 
-def env_required(name: str) -> str:
-    value = os.getenv(name)
-    if not value:
-        raise RuntimeError(f"Falta variable de entorno: {name}")
-    return value
-
-
-def arg_or_env(value: Optional[str], env_name: str) -> str:
-    if value:
-        return value
-    return env_required(env_name)
+# Ejecutado dentro del contenedor Odoo vía `docker exec -i <container> python3 -`.
+# Usa PGHOST/PGPORT/PGUSER/PGPASSWORD ya presentes en el entorno del contenedor.
+PAYLOAD = r'''
+import sys
+import psycopg2
 
 
 def list_databases(conn):
@@ -82,7 +75,7 @@ def get_presence_timestamp_field(conn):
     return None
 
 
-def count_online_users(conn, minutes: int, include_portal: bool):
+def count_online_users(conn, minutes, include_portal):
     with conn.cursor() as cur:
         cur.execute("SELECT to_regclass('public.bus_presence')")
         exists = cur.fetchone()[0] is not None
@@ -113,64 +106,11 @@ def count_online_users(conn, minutes: int, include_portal: bool):
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Cuenta usuarios online por base de datos Odoo"
-    )
-    parser.add_argument(
-        "instance",
-        help="Nombre de la instancia de Odoo",
-    )
-    parser.add_argument(
-        "--host",
-        help="Host de Postgres (override: usa instances.json por defecto)",
-    )
-    parser.add_argument(
-        "--port",
-        help="Puerto de Postgres (override: usa instances.json por defecto)",
-    )
-    parser.add_argument(
-        "--user",
-        help="Usuario de Postgres (override: usa instances.json por defecto)",
-    )
-    parser.add_argument(
-        "--password",
-        help="Password de Postgres (override: usa instances.json por defecto)",
-    )
-    parser.add_argument(
-        "--minutes",
-        type=int,
-        default=2,
-        help="Ventana en minutos para considerar usuario online (default: 2)",
-    )
-    parser.add_argument(
-        "--include-portal",
-        action="store_true",
-        help="Incluir usuarios portal/share",
-    )
-    args = parser.parse_args()
-
-    config = load_config(BASE_PATH)
-    instance = args.instance
-    if instance not in config["instances"]:
-        print(f"Error: instancia '{instance}' no existe")
-        sys.exit(1)
-
-    inst_conf = config["instances"][instance]
-    db_conf = resolve_db_config(inst_conf, config)
-    db_host = get_db_host(inst_conf["database"], db_conf)
-    db_user = db_conf["user"]
-    db_password = db_conf["password"]
-    db_port = db_conf["port"]
-
-    host = args.host or db_host
-    port = args.port or str(db_port)
-    user = args.user or db_user
-    password = args.password or db_password
+    minutes = int(sys.argv[1])
+    include_portal = sys.argv[2] == "1"
 
     try:
-        admin_conn = psycopg2.connect(
-            host=host, port=port, user=user, password=password, dbname="postgres"
-        )
+        admin_conn = psycopg2.connect(dbname="postgres")
         admin_conn.autocommit = True
     except Exception as e:
         print(f"Error conectando a postgres: {e}", file=sys.stderr)
@@ -186,13 +126,9 @@ def main():
 
     for dbname in dbs:
         try:
-            conn = psycopg2.connect(
-                host=host, port=port, user=user, password=password, dbname=dbname
-            )
+            conn = psycopg2.connect(dbname=dbname)
             conn.autocommit = True
-            count, status = count_online_users(
-                conn, minutes=args.minutes, include_portal=args.include_portal
-            )
+            count, status = count_online_users(conn, minutes, include_portal)
             conn.close()
 
             if count is None:
@@ -202,6 +138,48 @@ def main():
 
         except Exception as e:
             print(f"{dbname:40} {'-':>8} {'error: ' + str(e):>24}")
+
+
+if __name__ == "__main__":
+    main()
+'''
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Cuenta usuarios online por base de datos Odoo"
+    )
+    parser.add_argument(
+        "instance",
+        help="Nombre de la instancia de Odoo",
+    )
+    parser.add_argument(
+        "--minutes",
+        type=int,
+        default=2,
+        help="Ventana en minutos para considerar usuario online (default: 2)",
+    )
+    parser.add_argument(
+        "--include-portal",
+        action="store_true",
+        help="Incluir usuarios portal/share",
+    )
+    args = parser.parse_args()
+
+    config = load_config(BASE_PATH)
+    if args.instance not in config["instances"]:
+        print(f"Error: instancia '{args.instance}' no existe")
+        sys.exit(1)
+
+    container = f"odoo-{args.instance}"
+    cmd = [
+        "docker", "exec", "-i", container,
+        "python3", "-",
+        str(args.minutes),
+        "1" if args.include_portal else "0",
+    ]
+    result = subprocess.run(cmd, input=PAYLOAD.encode())
+    sys.exit(result.returncode)
 
 
 if __name__ == "__main__":

--- a/scripts/odoo_backup
+++ b/scripts/odoo_backup
@@ -15,6 +15,7 @@ from generators.config_loader import (
     load_config,
     resolve_db_config,
     get_db_host,
+    get_db_internal_port,
 )
 
 
@@ -937,7 +938,7 @@ def main():
     db_host = get_db_host(inst_conf["database"], db_conf)
     db_user = db_conf["user"]
     db_password = db_conf["password"]
-    db_port = db_conf["port"]
+    db_port = get_db_internal_port(db_conf)
     container_name = f"odoo-{instance}"
 
     # Si no se pasa -d, listar y elegir

--- a/scripts/odoo_restore
+++ b/scripts/odoo_restore
@@ -17,6 +17,7 @@ from generators.config_loader import (
     load_config,
     resolve_db_config,
     get_db_host,
+    get_db_internal_port,
 )
 
 
@@ -865,7 +866,7 @@ def main():
     db_conf = resolve_db_config(inst_conf, config)
     db_host = get_db_host(inst_conf["database"], db_conf)
     db_user = db_conf["user"]
-    db_port = db_conf["port"]
+    db_port = get_db_internal_port(db_conf)
     container_name = f"odoo-{instance}"
 
     restorer = RestoreOrchestrator(

--- a/scripts/odoo_restore_scp
+++ b/scripts/odoo_restore_scp
@@ -17,6 +17,7 @@ from generators.config_loader import (
     load_config,
     resolve_db_config,
     get_db_host,
+    get_db_internal_port,
 )
 
 
@@ -36,7 +37,7 @@ class EnvConfig:
 		db_conf = resolve_db_config(inst_conf, config)
 		db_host = get_db_host(inst_conf["database"], db_conf)
 		db_user = db_conf["user"]
-		db_port = db_conf["port"]
+		db_port = get_db_internal_port(db_conf)
 		container_name = f"odoo-{instance}"
 
 		return cls(


### PR DESCRIPTION
## Resumen
- Los contenedores Odoo se conectaban a Postgres via `host.docker.internal`, que en Docker Desktop enruta al loopback del host. Si hay un Postgres nativo corriendo ahi en el mismo puerto (Homebrew, Postgres.app), intercepta la conexion sin avisar; como no tiene el rol `odoo`, la instancia se queda esperando para siempre en `600-wait-postgress` y nunca termina de levantar (asi se detecto con `internal-19.0`).
- `get_db_host()` ahora devuelve el nombre del servicio Docker (`db-<nombre>`), alcanzable por la red interna sin pasar por el host. Se agrega `get_db_internal_port()` (5432 fijo, overrideable via `internal_port`) para los sitios que usaban `db_conf["port"]` (que es el puerto del host, no el del contenedor).
- Los contenedores de DB dejan de publicar su puerto al host por defecto (nuevo flag opt-in `expose_host_port` en `instances.json`), reduciendo superficie de ataque.
- `scripts/odoo_active_users` conectaba directo desde el host via `psycopg2`; se reescribe para correr la consulta dentro del contenedor Odoo (`docker exec`) ya que ese path deja de existir por defecto.
- Se quita el hack `extra_hosts: db:host-gateway` de pgAdmin, innecesario estando en la misma red que los contenedores de DB.

## Test plan
- [x] Regenerado `docker-compose.generated.yml` y confirmado que `db-pg16` ya no publica puertos salvo `expose_host_port: true`.
- [x] Recreados `db-pg16`, `odoo-internal-19.0` y `odoo-integra-19.0`; ambos responden `HTTP 200` en `/web/login`.
- [x] `docker exec ... psql --host db-pg16 --port 5432` confirma conectividad por la red interna.
- [x] `scripts/odoo_active_users internal-19.0` probado end-to-end contra el contenedor real.
- [x] Chequeo de sintaxis (`ast.parse`) en todos los archivos Python tocados.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>